### PR TITLE
More improvements to the schema guidelines

### DIFF
--- a/data/processed/defra/air_pollution_mean_pm10.yaml
+++ b/data/processed/defra/air_pollution_mean_pm10.yaml
@@ -24,9 +24,9 @@ region:
   level: 2
   source_url: https://ec.europa.eu/eurostat/cache/GISCO/distribution/v2/nuts/download/ref-nuts-2016-01m.shp.zip
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: mean pm10 particulate pollution value

--- a/data/processed/hesa/area_university_site.yaml
+++ b/data/processed/hesa/area_university_site.yaml
@@ -12,9 +12,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     format: .3f

--- a/data/processed/hesa/fte_research_students.yaml
+++ b/data/processed/hesa/fte_research_students.yaml
@@ -12,9 +12,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: Full Time Equivalent (FTE) research students

--- a/data/processed/hesa/gbp_research_income.yaml
+++ b/data/processed/hesa/gbp_research_income.yaml
@@ -12,9 +12,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: Research income for universities in the region

--- a/data/processed/hesa/total_postgraduates.yaml
+++ b/data/processed/hesa/total_postgraduates.yaml
@@ -12,9 +12,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: Total number of full-time students enrolled for postgraduate qualifications in universities in the area

--- a/data/processed/hesa/total_stem_postgraduates.yaml
+++ b/data/processed/hesa/total_stem_postgraduates.yaml
@@ -12,9 +12,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: Total number of full-time postgraduate students enrolled in STEM subjects in the area (definition of STEM subjects in aux folder)

--- a/data/processed/hesa/total_stem_students.yaml
+++ b/data/processed/hesa/total_stem_students.yaml
@@ -12,9 +12,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: Total number of full-time students enrolled in STEM subjects in the area

--- a/data/processed/hesa/total_university_buildings.yaml
+++ b/data/processed/hesa/total_university_buildings.yaml
@@ -12,9 +12,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: Total number of buildings in the area

--- a/data/processed/ref/mean_ref.yaml
+++ b/data/processed/ref/mean_ref.yaml
@@ -13,9 +13,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: The mean REF score for the NUTS2 area. This is the average of the scores in all departments weighted by the Full time equivalents submitted in each category (4*, 3*, 2* with higher scores representing better assessments)

--- a/data/processed/ref/mean_ref_stem.yaml
+++ b/data/processed/ref/mean_ref_stem.yaml
@@ -13,9 +13,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: The mean REF score for the NUTS2 area considering only STEM subjects (see aux/ref_stem.txt) for the subjects that we selected. This is the average of the scores in all departments weighted by the Full time equivalents submitted in each category (4*, 3*, 2* with higher scores representing better assessments)

--- a/data/processed/ref/total_4_fte.yaml
+++ b/data/processed/ref/total_4_fte.yaml
@@ -13,9 +13,9 @@ region:
   level: 2
   source_url: http://geoportal1-ons.opendata.arcgis.com/datasets/48b6b85bb7ea43699ee85f4ecd12fd36_0.zip?outSR=%7B%22latestWkid%22:27700,%22wkid%22:27700%7D
 schema:
-  region_id:
+  nuts_id:
     type: NutsRegion.id
-  region_year_spec:
+  nuts_year_spec:
     type: NutsRegion.year_spec
   value:
     description: The total number of excellent researchers (4* score) submitted by universities in the NUTS-2 region for the 2014 REF

--- a/data/schema/README.md
+++ b/data/schema/README.md
@@ -1,11 +1,11 @@
-# How to write a schema
+# How to provide schemas
 
 ## Simple indicators
 
 For simple indicators obtained from a single source, please refer to [`data/schema_template.yaml`](./schema_template.yaml): for each field, substitute type and comment with an actual value, with the exception of:
 
 ```yaml
-order: [year, nuts_id, nuts_year_spec, value.id]
+order: [year, <region_type>_id, <region_type>_year_spec, value.id]
 ```
 
 Keep this as is, eventually just remove the doc comment.

--- a/data/schema/schema_template.yaml
+++ b/data/schema/schema_template.yaml
@@ -1,13 +1,13 @@
 api_doc_url: URL # the URL of a documentation page with descriptions of the field meaning (if available)
 api_type: string # the type of API
-   # FETCH: the dataset can be downloaded at a specific URL
-    # this can be a direct URL to a file (e.g. www.download.com/datasets/companies.csv)
-    # or, the URL to a GET REST API (e.g. GET www.api.com/companies/London, returning a json response)
-   # POST: the data is obtained by querying a POST REST API with a custom API (e.g. posting {city: 'London'} to www.foo.com/companies and getting a json response)
+   # FETCH: the dataset can be downloaded at a specific URL; this can be:
+    # the URL of a file (e.g. www.download.com/datasets/companies.csv)
+    # or, the URL of a GET REST API (e.g. GET www.api.com/companies/London, returning a response in some format)
+   # POST: the data is obtained by querying a POST REST API with a custom API (e.g. POST-ing `{city: 'London'}` to www.foo.com/companies to get a json response)
    # ElasticSearch: the data is obtained by querying an ElasticSearch endpoint
    # Neo4j: the data is obtained by querying a Neo4j endpoint
    # MySQL: the data is obtained by querying a MySQL endpoint
-data_date: Date_YYYYMMDD
+data_date: Date_YYYYMMDD # OPTIONAL - the date of the data processing, e.g. 20201213
 description_short: string # a brief description of the indicator short enough to be used in menus or sidebars (~40 chars)
 description: string # a description of the indicator, of the data source and transformations that have been applied
 endpoint_url: URL|URL[] # use and array of URLs if multiple files have been downloaded to build this indicator
@@ -16,24 +16,25 @@ endpoint_url: URL|URL[] # use and array of URLs if multiple files have been down
 derived_from: string[] # OPTIONAL - list of indicator keys this indicator derives from
 framework_group: string # key for the framework group that contains this indicator (from data/aux/framework.json)
 is_experimental: boolean # whether this indicator is experimental
-order: [year, nuts_id, nuts_year_spec, value.id] # USE AS IS: it specifies the order of the exported indicator fields
+order: [year, <region_type>_id, <region_type>_year_spec, value.id] # it specifies the order of the exported indicator fields, please substitute `<region_type>` with ` nuts` or `lep`, etc (see GeoRegion.region_type)
+query: string # OPTIONAL - the query we POST-ed (not needed for FETCH), e.g. `{city: 'London'}` in the POST example above, or the query sent to  ElasticSearch, etc.
 region:
   type: string # the region type, e.g. NutsRegion or LepRegion
   level: int # OPTIONAL - useful for NUTS
   source_url: GeoRegion.source_url # OPTIONAL - see GeoRegion in types.yaml
   source: GeoRegion.source # OPTIONAL - see GeoRegion docs in types.yaml
 schema:
-  region_id:
-    type: string # NutsRegion.id or LepRegion.id
-  region_year_spec:
-    type: string # NutsRegion.year_spec or LepRegion.year_spec
+  <region_type>_id: # change this key to `nuts_id` or `lep_id`
+    type: GeoRegion.<region_type>_id # change this key to `GeoRegion.nuts_id` or `GeoRegion.lep_id`
+  <region_type>_year_spec: # change this key to `nuts_year_spec` or `lep_year_spec`
+    type: GeoRegion.<region_type>_year_spec # change this key to `GeoRegion.nuts_year_spec` or `GeoRegion.lep_year_spec`
   value:
     description: string # a description of the value
     format: string # OPTIONAL - the render format, useful for floats or dates (e.g. `.2f`), see [1] and [2]
     id: string # indicator name, should be identical to the file name (e.g. `berd` and `berd.csv`)
     label: string # a short text to be used as a label in charts
     type: string # (XOR `data_type`) - the value Type (e.g. Euro). Consider using `data_type` first.
-    data_type: string # (XOR `type`) - use for native types like counts (int) or simple mean values (float). Consider using `type` if th unit has a well known Type (e.g. EUR, densities, etc.)
+    data_type: string # (XOR `type`) - use for native types like counts (int) or simple mean values (float). Consider using `type` if the unit has a well known Type (e.g. EUR, densities, etc.)
   year:
     data_type: int
     label: Year

--- a/data/schema/types.yaml
+++ b/data/schema/types.yaml
@@ -14,13 +14,14 @@ URL:
 # GEOGRAPHY
 
 GeoRegion:
-  id: string # NUTS region ID e.g. UKF2
-  name: string # name of the region
-  level: int # e.g. 2
+  <region_type>_id: string # the region id e.g. UKF2 (here the key can be `nuts_id`, `lep_id`, etc)
+  <region_type>_year_enforced: int # OPTIONAL - year of spec being enforced (here the key can be `nuts_year_enforced`, `lep_year_enforced`, etc)
+  <region_type>_year_spec: int # year of specification release (here the key can be `nuts_year_spec`, `lep_year_spec`, etc)
+  level: int # OPTIONAL – used for NUTS, e.g. 2
+  name: string # name of the region, e.g. Cornwall, France
+  region_type: string # the region type (e.g. `nuts`, `lep`, etc)
   source_url: URL # OPTIONAL - url of the boundaries used for reverse geocoding, if known
   source: string # OPTIONAL - use `PROVIDED` in case `source_url` is unknown because the data have already been reverse geocoded
-  year_enforced: int # OPTIONAL - year of spec being enforced
-  year_spec: int # year of specification release
 
 
 # UNITS

--- a/data/schema/types_schema.yaml
+++ b/data/schema/types_schema.yaml
@@ -1,23 +1,25 @@
 # GEOGRAPHY
 
 NutsRegion:
-  id: GeoRegionint.id # e.g. UKF2
-  level: int # e.g. 2
-  name: GeoRegionint.name # e.g. Leicestershire, Rutland and Northamptonshire
-  source_url: GeoRegionint.source_url
-  source: GeoRegionint.source
+  level: int # e.g. 1|2|3
+  name: GeoRegion.name # e.g. Leicestershire, Rutland and Northamptonshire
+  nuts_id: GeoRegion.<region_type>_id # e.g. UKF2
+  nuts_year_enforced: GeoRegion.<region_type>_year_enforced
+  nuts_year_spec: GeoRegion.<region_type>_year_spec
+  region_type: nuts
+  source_url: GeoRegion.source_url
+  source: GeoRegion.source
   type: GeoRegion
-  year_enforced: GeoRegionint.year_enforced
-  year_spec: GeoRegionint.year_spec
 
 LepRegion:
-  id: GeoRegionint.id # e.g. E37000001
-  name: GeoRegionint.name # e.g. Black Country
-  source_url: GeoRegionint.source_url
-  source: GeoRegionint.source
+  lep_id: GeoRegion.id # e.g. E37000001
+  lep_year_enforced: GeoRegion.year_enforced
+  lep_year_spec: GeoRegion.year_spec
+  name: GeoRegion.name # e.g. Black Country
+  region_type: lep
+  source_url: GeoRegion.source_url
+  source: GeoRegion.source
   type: GeoRegion
-  year_enforced: GeoRegionint.year_enforced
-  year_spec: GeoRegionint.year_spec
 
 
 # UNITS


### PR DESCRIPTION
- adds `query`
- use dynamic keys for `GeoRegion`
  - `<region_type>_id`
  - `<region_type>_year_enforced`
  - `<region_type>_year_spec`
  so that the region type is explicit (`nuts_id` vs `lep_id`)

Closes #134 (again)