### PR TITLE
Add indicator trends

### DIFF
--- a/ds/data/processed/eurostat/eurostat_private_non_profit_rd_workforce_data.yaml
+++ b/ds/data/processed/eurostat/eurostat_private_non_profit_rd_workforce_data.yaml
@@ -26,4 +26,4 @@ schema:
     data_type: int
     label: Year
 source_name: Eurostat
-year_range: [2012, 2016]
+year_range: [2012, 2017]

--- a/ds/data/processed/gtr/total_gtr_projects_stem.yaml
+++ b/ds/data/processed/gtr/total_gtr_projects_stem.yaml
@@ -21,6 +21,7 @@ schema:
     type: NutsRegion.year_spec
   value:
     description: Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)
+    format: ','
     id: total_gtr_projects_stem
     label: Number of projects in STEM disciplines led by organisations in the region
     data_type: int

--- a/ds/data/processed/trademarks/total_trademarks.yaml
+++ b/ds/data/processed/trademarks/total_trademarks.yaml
@@ -25,4 +25,4 @@ schema:
     data_type: int
     label: Year
 source_name: IPO (https://www.gov.uk/government/organisations/intellectual-property-office)
-year_range: [2010, 2017]
+year_range: [2010, 2018]

--- a/ds/data/processed/trademarks/total_trademarks_scientific.yaml
+++ b/ds/data/processed/trademarks/total_trademarks_scientific.yaml
@@ -25,4 +25,4 @@ schema:
     data_type: int
     label: Year
 source_name: IPO (https://www.gov.uk/government/organisations/intellectual-property-office)
-year_range: [2010, 2017]
+year_range: [2010, 2018]

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1623,6 +1623,16 @@
         "d3-color": "1"
       }
     },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
+    "d3-quadtree": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
     "d3-scale": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.2.1.tgz",
@@ -1648,6 +1658,14 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.1.tgz",
       "integrity": "sha512-BTIbRjv/m5rcVTfBs4AMBLKs4x8XaaLkwm28KWu9S2vKNqXkXt2AH2Qf0sdPZHjFxcWg/YL53zcqAz+3g4/7PA=="
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
     },
     "d3-time": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,8 +8,10 @@
     "d3-array": "^2.4.0",
     "d3-dsv": "^1.2.0",
     "d3-format": "^1.4.4",
+    "d3-quadtree": "^1.0.7",
     "d3-scale": "^3.2.1",
     "d3-scale-chromatic": "^1.5.0",
+    "d3-shape": "^1.3.7",
     "lamb": "^0.58.0",
     "polka": "^0.5.2",
     "rollup": "^2.3.3",
@@ -54,5 +56,5 @@
     "test": "run-p --race dev cy:run",
     "unittest": "mocha -r esm --spec src/**/*.spec.js"
   },
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/ui/src/node_modules/app/components/Timeline.svelte
+++ b/ui/src/node_modules/app/components/Timeline.svelte
@@ -1,7 +1,6 @@
 <script>
 	import { getContext } from 'svelte';
 	import * as _ from 'lamb';
-	import { linearScale } from 'yootils';
 
 	import { goto } from '@sapper/app';
 	import { yearRange } from 'app/data/groups';

--- a/ui/src/node_modules/app/data/indicatorsGroups.json
+++ b/ui/src/node_modules/app/data/indicatorsGroups.json
@@ -333,7 +333,7 @@
         "source_name": "Eurostat",
         "year_range": [
           2012,
-          2016
+          2017
         ],
         "url": "https://raw.githubusercontent.com/nestauk/beis-indicators/dev/ds/data/processed/eurostat/eurostat_private_non_profit_rd_workforce_data.csv"
       },
@@ -369,6 +369,7 @@
           },
           "value": {
             "description": "Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)",
+            "format": ",",
             "id": "total_gtr_projects_stem",
             "label": "Number of projects in STEM disciplines led by organisations in the region",
             "data_type": "int"
@@ -1552,7 +1553,7 @@
         "source_name": "IPO (https://www.gov.uk/government/organisations/intellectual-property-office)",
         "year_range": [
           2010,
-          2017
+          2018
         ],
         "url": "https://raw.githubusercontent.com/nestauk/beis-indicators/dev/ds/data/processed/trademarks/total_trademarks.csv"
       },
@@ -1597,7 +1598,7 @@
         "source_name": "IPO (https://www.gov.uk/government/organisations/intellectual-property-office)",
         "year_range": [
           2010,
-          2017
+          2018
         ],
         "url": "https://raw.githubusercontent.com/nestauk/beis-indicators/dev/ds/data/processed/trademarks/total_trademarks_scientific.csv"
       }

--- a/ui/src/node_modules/app/stores.js
+++ b/ui/src/node_modules/app/stores.js
@@ -9,24 +9,48 @@ export const lookupStore = writable(lookup);
 
 /* layout */
 
-const safety = 10;
+export const safetyDefault = {left: 80, right: 80};
+export const safetyStore = writable(safetyDefault);
+export const resetSafetyStore = () => {
+  safetyStore.set(safetyDefault);
+}
 
 export const timelineHeightStore = writable(0);
 export const timelineWidthStore = writable(0);
+
 export const timelineLayoutStore = derived([
   timelineHeightStore,
-  timelineWidthStore
-], ([height, width]) => {
+  timelineWidthStore,
+  safetyStore
+], ([height, width, safety]) => {
+  const padding = 10;
   const fontSize = Math.min(height / 4, 14);
   const radius = Math.min(height / 8, 7);
-  const start = radius + safety;
-  const end = width - start;
+  const fullExtent = [
+    padding + radius,
+    width - padding - radius
+  ];
+  const fullScaleX = linearScale(yearExtent, fullExtent);
+  const start = fullExtent[0] + safety.left;
+  const end = fullExtent[1] - safety.right;
   const scaleX = linearScale(yearExtent, [start, end]);
   const y1 = height / 3;
   const y2 = (height + y1 + radius) / 2;
   const ym = height / 2;
 
-  return {height, width, fontSize, radius, start, end, scaleX, y1, y2, ym}
+  return {
+    end,
+    fontSize,
+    fullScaleX,
+    height,
+    radius,
+    scaleX,
+    start,
+    width,
+    y1,
+    y2,
+    ym,
+  }
 });
 
 /* selection */
@@ -37,6 +61,7 @@ export const resetSelectedYear = () => {
 }
 
 export const availableYearsStore = writable([]);
+
 export const resetSelection = () => {
   availableYearsStore.set([]);
   resetSelectedYear();

--- a/ui/src/node_modules/app/utils.js
+++ b/ui/src/node_modules/app/utils.js
@@ -1,13 +1,30 @@
+import {csvParse} from 'd3-dsv';
+import {format} from 'd3-format';
+import {interpolateWarm} from 'd3-scale-chromatic';
+import {scaleQuantize} from 'd3-scale';
 import * as _ from 'lamb';
 import {
-  arrayMin,
   arrayMax,
-  makeArrayTransformer
+  arrayMin,
+  inclusiveRange,
+  makeArrayTransformer,
+  transformValues,
 } from '@svizzle/utils';
 
 export {version} from '../../../package.json';
 
+/* svizzle */
+
+// obj[] => obj[]
+// setIndexAsKey([{a: 2}, {c: 5}]) => [{a: 2, index: 0}, {c: 5, index: 1}]
+export const setIndexAsKey = key => _.pipe([
+  _.zipWithIndex,
+  _.mapWith(([obj, index]) => _.setIn(obj, key, index))
+]);
+
 /* domain */
+
+export const getNutsId = _.getKey('nuts_id');
 
 export const getYearExtent = _.pipe([
   _.pluckKey('indicators'),
@@ -15,10 +32,39 @@ export const getYearExtent = _.pipe([
   _.pluckKey('year_range'),
   _.transpose,
   makeArrayTransformer([arrayMin, arrayMax]),
-]);
+]); // IDEA just flatten and get the whole extent
 
 export const makeIndicatorsLookup = _.pipe([
   _.pluckKey('indicators'),
   _.flatten,
   _.indexBy(_.getPath('schema.value.id')),
 ]);
+
+export const makeValueAccessor = id => _.getKey(id);
+export const sortAscByYear = _.sortWith([_.sorter(_.getKey('year'))]);
+
+const sanitizeValue = _id => transformValues({
+  [_id]: Number,
+  // year: Number
+});
+export const parseCSV = id =>
+  t => csvParse(t, sanitizeValue(id));
+
+// color scale
+
+const steps = inclusiveRange([0, 1, 0.25]);
+const colorRange = _.map(steps, interpolateWarm);
+const colorScale = scaleQuantize().range(colorRange);
+
+export const makeColorScale = extent => colorScale.domain([0, extent[1]]);
+
+// format
+
+export const getIndicatorFormat = (id, lookup) => _.pipe([
+  _.getPath(`${id}.schema.value`),
+  _.condition(
+    _.hasKey('format'),
+    value => format(value.format),
+    () => _.identity,
+  )
+])(lookup);

--- a/ui/src/routes/feedback.svelte
+++ b/ui/src/routes/feedback.svelte
@@ -8,6 +8,7 @@
 
 <main>
 	<iframe
+		title='User testing survey'
 		src={userTestingUrl}
 	/>
 </main>

--- a/ui/src/routes/indicators/[id]/index.svelte
+++ b/ui/src/routes/indicators/[id]/index.svelte
@@ -1,36 +1,409 @@
-<script context="module">
-  export async function preload({ params: id, query }) {
-    return id;
-  }
+<script context='module'>
+	export function preload({ params: {id}, query }) {
+		return this.fetch(lookup[id].url)
+			.then(r => r.text())
+			.then(parseCSV(id))
+			.then(data => ({data, id}))
+	}
 </script>
 
 <script>
-  import * as _ from 'lamb';
-  import {inclusiveRange} from '@svizzle/utils';
+	import {writable} from 'svelte/store';
+	import * as _ from 'lamb';
+	import {extent, max} from 'd3-array';
+	import {quadtree} from 'd3-quadtree';
+	import {scaleLinear} from 'd3-scale';
+	import {line, curveMonotoneX} from 'd3-shape';
+	import {makeStyle, toPx} from '@svizzle/dom';
+	import {
+		applyFnMap,
+		inclusiveRange,
+		mergeObj,
+		objectToKeyValueArray,
+		transformValues
+	} from '@svizzle/utils';
 
-  import {lookup} from 'app/data/groups';
-  import {availableYearsStore, resetSelectedYear} from 'app/stores';
+	import { goto } from '@sapper/app';
+	import { lookup, yearExtent, yearRange } from 'app/data/groups';
+	import groups from 'app/data/indicatorsGroups.json';
+	import yearlyKeyToLabel from 'app/data/NUTS2_UK_labels';
+	import {
+		availableYearsStore,
+		lookupStore,
+		resetSelectedYear,
+		safetyStore,
+		timelineLayoutStore
+	} from 'app/stores';
+	import {
+		getIndicatorFormat,
+		getNutsId,
+		makeColorScale,
+		makeValueAccessor,
+		parseCSV,
+		setIndexAsKey,
+		sortAscByYear,
+	} from 'app/utils';
 
-  export let id;
+	const makeSetOrderWith = accessor => _.pipe([
+		_.groupBy(_.getKey('year')),
+		_.mapValuesWith(_.pipe([
+			_.sortWith([_.sorterDesc(accessor)]),
+			setIndexAsKey('order')
+		])),
+		_.values,
+		_.flatten,
+	]);
 
-  $: id && resetSelectedYear();
-  $: $availableYearsStore = inclusiveRange(lookup[id].year_range)
-  $: makeRoutes = _.pipe([
-    inclusiveRange,
-    _.mapWith(year => [year, `/indicators/${id}/${year}`])
-  ]);
-  $: routes = makeRoutes(lookup[id].year_range);
+	const makeTrends = _.pipe([
+		_.groupBy(getNutsId),
+		_.mapValuesWith(sortAscByYear),
+		objectToKeyValueArray
+	]);
+	const getOrder = _.getKey('order');
+
+	const gap = 4;
+	const labelSafety = 75;
+	const tooltipFontSize = 10;
+	const tooltipPadding = 5;
+	const tooltipShift = 1.5 * tooltipPadding + 0.5 * tooltipFontSize;
+
+  export let data;
+	export let id;
+
+	let height;
+	let highlightedKey;
+	let width;
+	let useOrderScale = false;
+
+	$: id && resetSelectedYear();
+	$: data && lookupStore.update(_.setPath(`${id}.data`, data));
+
+	$: ({description, description_short, year_range} = $lookupStore[id] || {});
+	$: formatFn = getIndicatorFormat(id, lookup);
+	$: $availableYearsStore = inclusiveRange(year_range)
+	$: layout = $timelineLayoutStore;
+
+	$: getIndicatorValue = makeValueAccessor(id);
+	$: setOrder = makeSetOrderWith(getIndicatorValue);
+	$: rankedData = setOrder(data);
+	$: maxOrder = max(rankedData, getOrder);
+	$: valueExtext = extent(data, getIndicatorValue);
+	$: trends = makeTrends(rankedData);
+	$: radius = Math.min(layout.radius, 0.5 * (height / maxOrder) - gap);
+	$: yMin = radius + gap;
+	$: yMax = height - radius - gap;
+	$: scaleY = useOrderScale
+		? scaleLinear().domain([0, maxOrder]).range([yMin, yMax])
+		: scaleLinear().domain(valueExtext).range([yMax, yMin]);
+	$: ticks = scaleY && scaleY.ticks().map(value => ({
+		label: useOrderScale ? value : formatFn(value),
+		y: scaleY(value)
+	}));
+	$: getX = d => layout.scaleX(d.year);
+	$: getY = d => useOrderScale ? scaleY(d.order) : scaleY(getIndicatorValue(d));
+	$: lineGenerator =
+		line()
+		.x(getX)
+		.y(getY)
+		.curve(curveMonotoneX);
+	$: trendLines = _.map(trends, transformValues({value: lineGenerator}));
+	$: colorScale = makeColorScale(valueExtext);
+	$: getStopOffset = d => `${100 * layout.scaleX(d.year) / width}%`;
+	$: gradients = _.map(trends, transformValues({
+		value: _.mapWith(applyFnMap({
+			offset: getStopOffset,
+			stopColor: _.pipe([getIndicatorValue, colorScale])
+		}))
+	}));
+
+	$: X1 = layout.fullScaleX(year_range[0]);
+	$: X2 = layout.fullScaleX(year_range[1]);
+	$: x1 = layout.scaleX(year_range[0]);
+	$: x2 = layout.scaleX(year_range[1]);
+
+	/* tooltip */
+
+	$: quadTree = rankedData &&
+		quadtree()
+		.x(getX)
+		.y(getY)
+		.addAll(rankedData)
+		.extent([[x1, 0],[x2, height]]);
+
+	const tooltipDefault = {isVisible: false};
+	const tooltip = writable(tooltipDefault);
+
+	const onMousemoved = event => {
+		const {offsetX, offsetY} = event;
+
+		if (offsetX < x1 || offsetX > x2) {
+			tooltip.set(tooltipDefault);
+			return;
+		}
+
+		const datum = quadTree.find(offsetX, offsetY);
+		const {nuts_id, nuts_year_spec} = datum;
+
+		highlightedKey = nuts_id;
+		const keyToLabel = yearlyKeyToLabel[nuts_year_spec];
+		const dotX = getX(datum);
+		const dotY = getY(datum);
+		const isRight = dotX > (X1 + X2) / 2;
+		const shiftX = isRight ? -tooltipShift : tooltipShift;
+		const shiftY =
+			Math.max(yMin + tooltipShift, Math.min(dotY, yMax - tooltipShift)) - dotY;
+
+		tooltip.update(mergeObj({
+			isVisible: true,
+			...datum,
+			nuts_label: `${keyToLabel[nuts_id]} (${nuts_id})`,
+			value: formatFn(getIndicatorValue(datum)),
+			dotX,
+			dotY,
+			isRight,
+			shiftX,
+			shiftY,
+		}));
+	};
 </script>
 
-<ul>
-  {#each routes as [year, href]}
-  <li>
-    <a
-      rel='prefetch'
-      {href}
-    >
-      <p>{year}</p>
-    </a>
-  </li>
-  {/each}
-</ul>
+<svelte:head>
+	<title>{description_short}</title>
+</svelte:head>
+
+<div class='container'>
+	<header>
+		<h1>{description_short}</h1>
+		<h2>{description}</h2>
+	</header>
+
+	<section>
+		<div class='controls'>
+			<button
+				on:click='{() => {useOrderScale = true}}'
+				class:selected={useOrderScale}
+			>Relative</button>
+			<button
+				class:selected={!useOrderScale}
+				on:click='{() => {useOrderScale = false}}'
+			>Absolute</button>
+		</div>
+		<div
+			class='trends'
+			bind:clientHeight={height}
+			bind:clientWidth={width}
+			on:mousemove={onMousemoved}
+		>
+			{#if width && trends}
+			<svg
+				{width}
+				{height}
+			>
+				<defs>
+					{#each gradients as {key, value}}
+					<linearGradient
+						id={key}
+						gradientUnits='userSpaceOnUse'
+					>
+						{#each value as {offset, stopColor}}
+						<stop {offset} stop-color={stopColor} />
+						{/each}
+					</linearGradient>
+					{/each}
+				</defs>
+
+				<!-- axes -->
+				<g>
+					<g class='ref x'>
+						{#each $availableYearsStore as year}
+						<line
+							x1={layout.scaleX(year)}
+							x2={layout.scaleX(year)}
+							y2={height}
+						/>
+						{/each}
+					</g>
+					{#each ticks as {label, y}}
+					<g
+						class='ref left'
+						transform='translate({x1},0)'
+					>
+						<line x2='-10' y1={y} y2={y}/>
+						<text dx='-15' dy={y}>{label}</text>
+					</g>
+					<g
+						class='ref right'
+						transform='translate({x2},0)'
+					>
+						<line x2='10' y1={y} y2={y}/>
+						<text dx='15' dy={y}>{label}</text>
+					</g>
+					{/each}
+				</g>
+
+				<!-- curves -->
+				<g>
+					{#each trendLines as {key, value}}
+					<path
+						class:focused='{$tooltip.isVisible && highlightedKey === key}'
+						class:dimmed='{$tooltip.isVisible && highlightedKey !== key}'
+						stroke='url(#{key})'
+						d={value}
+					/>
+					{/each}
+				</g>
+
+				<!-- single year: dots -->
+				{#if $availableYearsStore.length === 1}
+				<g>
+				{#each trends as {key, value}}
+					{#each value as d}
+						<circle
+							cx={getX(d)}
+							cy={getY(d)}
+							r={radius}
+						/>
+					{/each}
+				{/each}
+				</g>
+				{/if}
+
+				{#if $tooltip.isVisible}
+				<g
+					class='marker'
+					transform='translate({$tooltip.dotX},{$tooltip.dotY})'
+				>
+					<circle r={radius} />
+					<g
+						class:right={$tooltip.isRight}
+						transform='translate({$tooltip.shiftX},{$tooltip.shiftY})'
+					>
+						<text dy={-tooltipShift} class='bkg'>{$tooltip.value}</text>
+						<text dy={-tooltipShift}>{$tooltip.value}</text>
+						<text dy={tooltipShift} class='bkg'>{$tooltip.nuts_label}</text>
+						<text dy={tooltipShift}>{$tooltip.nuts_label}</text>
+					</g>
+				</g>
+				{/if}
+			</svg>
+			{/if}
+		</div>
+	</section>
+</div>
+
+<style>
+	.container {
+		--indicators-h1-height: 4.5rem;
+		height: 100%;
+		width: 100%;
+	}
+
+	header {
+		height: var(--indicators-h1-height);
+	}
+
+	section {
+		height: calc(100% - var(--indicators-h1-height));
+		width: 100%;
+		overflow-y: auto;
+		display: grid;
+		grid-template-columns: 100%;
+		grid-template-rows: 3rem calc(100% - 3rem);
+	}
+
+	h2 {
+		font-style: italic;
+		font-size: 1rem;
+		color: grey;
+	}
+
+	.controls {
+		height: 100%;
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+	}
+
+	button {
+		background-color: white;
+		border: 1px solid var(--color-main);
+		cursor: pointer;
+		font-size: 1rem;
+		margin-right: 1rem;
+		padding: 0.5rem;
+		user-select: none;
+	}
+	button.selected {
+		background-color: var(--color-selected);
+		color: white;
+	}
+
+	.trends {
+		position: relative;
+	}
+
+	.trends, svg {
+		height: 100%;
+		width: 100%;
+	}
+
+	svg .ref line {
+		stroke: var(--color-grey-180);
+		pointer-events: none;
+	}
+	svg .x line {
+		stroke-dasharray: 2 2;
+		pointer-events: none;
+	}
+	svg text {
+		fill: var(--color-grey-180);
+		dominant-baseline: middle;
+		font-weight: var(--dim-fontsize-light);
+		stroke: none;
+		pointer-events: none;
+	}
+	svg .left text {
+		text-anchor: end;
+	}
+	svg .right text {
+		text-anchor: start;
+	}
+
+	svg path {
+		fill: none;
+		pointer-events: none;
+		/* stroke-width: 0.7; */
+	}
+	svg path.focused {
+		stroke-width: 3;
+	}
+	svg path.dimmed {
+		stroke-opacity: 0.5;
+	}
+
+	svg circle {
+		fill: white;
+		stroke: black;
+		stroke-width: 1.5;
+		pointer-events: none;
+	}
+
+	/* marker */
+
+	svg .marker text {
+		fill: black;
+		dominant-baseline: middle;
+		pointer-events: none;
+	}
+	svg .marker text.bkg {
+		fill: none;
+		stroke: white;
+		stroke-width: 5;
+		stroke-linecap: round;
+		stroke-linecap: round;
+	}
+	svg .marker .right text {
+		text-anchor: end;
+	}
+</style>

--- a/ui/src/routes/indicators/_layout.svelte
+++ b/ui/src/routes/indicators/_layout.svelte
@@ -12,11 +12,7 @@
 		timelineWidthStore,
 	} from 'app/stores';
 
-	setContext('layout', {
-		timelineHeightStore,
-		timelineWidthStore,
-		timelineLayoutStore
-	});
+	setContext('layout', {timelineLayoutStore});
 
 	export let segment;
 </script>
@@ -73,7 +69,7 @@
 		background-color: var(--color-main);
 		border-right: 1px solid var(--color-main-lighter);
 		color: white;
-		font-weight: 200;
+		font-weight: var(--dim-fontsize-light);
 	}
 	.container > nav a {
 		text-decoration: none;
@@ -90,8 +86,6 @@
 	.container > nav p:hover {
 		cursor: pointer;
 		background-color: var(--color-selected);
-		/* font-weight: 600; */
-		/* background-color: var(--color-grey-lighter); */
 	}
 
 	.content {

--- a/ui/src/routes/indicators/index.svelte
+++ b/ui/src/routes/indicators/index.svelte
@@ -1,12 +1,11 @@
 <script>
 	import * as _ from 'lamb';
-	import { linearScale } from 'yootils';
 	import {inclusiveRange} from '@svizzle/utils';
 
 	import { goto } from '@sapper/app';
 	import { yearExtent, yearRange } from 'app/data/groups';
 	import groups from 'app/data/indicatorsGroups.json';
-	import {resetSelection} from 'app/stores';
+	import {resetSafetyStore, resetSelection} from 'app/stores';
 
 	import { getContext } from 'svelte';
 
@@ -14,6 +13,7 @@
 	const gap = 7;
 
 	resetSelection();
+	resetSafetyStore();
 
 	let height;
 	let width;
@@ -44,7 +44,7 @@
 				{#if width}
 				<svg
 					{width}
-					height='{4 * layout.start + vStep * indicators.length}'
+					height='{4 * gap + layout.fontSize + vStep * indicators.length}'
 				>
 					{#each yearRange as year}
 					<g
@@ -52,11 +52,12 @@
 						transform='translate({layout.scaleX(year)},0)'
 					>
 						<line
-							y1='{layout.start}'
-							y2='{layout.start + vStep * indicators.length}'
+							y1='{gap}'
+							y2='{gap + vStep * indicators.length}'
 						/>
 						<text
-							y='{2 * layout.start + vStep * indicators.length + gap}'
+							font-size={layout.fontSize}
+							y='{2 * gap + vStep * indicators.length + layout.fontSize / 2}'
 						> {year}
 						</text>
 					</g>
@@ -67,6 +68,12 @@
 						class='indicatorsrange'
 						transform='translate(0,{vStep * (y + 1)})'
 					>
+						<text
+							class='bkg'
+							x='{(layout.scaleX(year_range[0]) + layout.scaleX(year_range[1])) / 2}'
+							dy='{-(layout.fontSize + gap)}'
+							font-size={layout.fontSize}
+						>{description_short}</text>
 						<text
 							x='{(layout.scaleX(year_range[0]) + layout.scaleX(year_range[1])) / 2}'
 							dy='{-(layout.fontSize + gap)}'
@@ -155,6 +162,10 @@
 		dominant-baseline: middle;
 		text-anchor: middle;
 		pointer-events: none;
+	}
+	svg .indicatorsrange text.bkg {
+		stroke: white;
+		stroke-width: 5;
 	}
 
 	svg .indicatorsrange circle {

--- a/ui/src/routes/methodology.svelte
+++ b/ui/src/routes/methodology.svelte
@@ -1,9 +1,11 @@
 <script>
+	const crunchbaseUrl = 'https://www.crunchbase.com/';
 	const eurostatUrl = 'https://ec.europa.eu/eurostat';
 	const hesaUrl = 'https://www.hesa.ac.uk';
 	const lepUrl = 'https://geoportal.statistics.gov.uk/search?collection=Dataset&sort=name&tags=all(BDY_LEP)';
 	const nutsUrl = 'https://ec.europa.eu/eurostat/web/gisco/geodata/reference-data/administrative-units-statistical-units/nuts';
 	const onsUrl = 'https://ons.gov.uk';
+	const patstatUrl = 'https://www.epo.org/searching-for-patents/business/patstat.html';
 	const ukriUrl = 'https://www.ukri.org/';
 </script>
 
@@ -18,7 +20,7 @@
 		<h2>Data sources</h2>
 
 		<p>As much as possible we have used data from official sources such as <a href={onsUrl}>ONS</a>, <a href={eurostatUrl}>Eurostat</a>, <a href={hesaUrl}>HESA</a> or <a href={ukriUrl}>UKRI</a>. One reason to do this is to enable the reproducibility of our analysis, and to remove the reliance of the tool on proprietary sources.<p>
-		<p>Having said this, in a small number of instances we have used proprietary data sources such as PATSTAT for the analysis of patenting, and CrunchBase for the analysis of venture capital investment.<p>
+		<p>Having said this, in a small number of instances we have used proprietary data sources such as <a href={patstatUrl}>PATSTAT</a> for the analysis of patenting, and <a href={crunchbaseUrl}>Crunchbase</a> for the analysis of venture capital investment.<p>
 
 		<h2>Geographies</h2>
 

--- a/ui/static/global.css
+++ b/ui/static/global.css
@@ -52,11 +52,13 @@ a {
 	--color-main: rgb(16, 174, 249);
 	--color-selected: lightseagreen; /* dodgerblue */
 	--color-grey-lighter: #f7f7f7;
+	--color-grey-180: rgb(180, 180, 180);
 	--color-grey-70: rgb(70, 70, 70);
 	--color-grey-40: rgb(40, 40, 40);
 	--color-paleyellow: #f9f7dd;
 	--color-link: var(--color-main);
 	--color-background: var(--color-main-lighter);
+	--dim-fontsize-light: 200;
 	--dim-header-height: 3rem;
 	--dim-main-height: calc(100% - var(--dim-header-height));
 	--dim-padding-minor: 0.5rem;


### PR DESCRIPTION
Closes #198

Also:
- `indicators/[id]/[year].svelte`:
  - barchart: reset the scroll when we select a new year
  - fixed a glitch in the map tooltip not showing zeroes
  (e.g. regions at the bottom of the barchart at [1] are zeroes: hovering them on the map wasn't showing the value)
- `indicators/index.svelte`: add a white background to labels to ease readability
- schemas:
  - fixed `year_range` for:
    - `eurostat_private_non_profit_rd_workforce_data`
    - `total_trademarks`
    - `total_trademarks_scientific`
  - added `format` for `total_gtr_projects_stem`
- `methodology.svelte`: add links for Crunchbase and PATSTAT
- version bump: 0.0.3