### PR TITLE
Show long descriptions

### DIFF
--- a/ui/src/node_modules/app/components/Modal.svelte
+++ b/ui/src/node_modules/app/components/Modal.svelte
@@ -17,6 +17,7 @@
 	export let api_type;
 	export let auth_provider;
 	export let data_date;
+	export let description_long;
 	export let endpoint_url;
 	export let is_experimental;
 	export let is_public;
@@ -37,6 +38,9 @@
 		on:click|stopPropagation={noop}
 	>
 		<h2>About the data</h2>
+		{#if description_long}
+		<p class="longDesc">{description_long}</p>
+		{/if}
 		<p>
 			<b>Source:</b>
 			<ExternalLink href={source_url} text={source_name}/>
@@ -146,6 +150,10 @@
 		max-width: 800px;
 		padding: 1rem;
 		overflow-y: auto;
+	}
+
+	.longDesc {
+		margin-bottom: 1rem;
 	}
 
 	b {

--- a/ui/src/routes/indicators/[id]/[year].svelte
+++ b/ui/src/routes/indicators/[id]/[year].svelte
@@ -94,6 +94,7 @@
 		api_type,
 		auth_provider,
 		data_date,
+		description_long,
 		description_short,
 		description,
 		endpoint_url,
@@ -347,6 +348,7 @@
 			{api_type}
 			{auth_provider}
 			{data_date}
+			{description_long}
 			{endpoint_url}
 			{is_public}
 			{query}

--- a/ui/src/routes/indicators/[id]/index.svelte
+++ b/ui/src/routes/indicators/[id]/index.svelte
@@ -93,6 +93,7 @@
 		auth_provider,
 		data_date,
 		description_short,
+		description_long,
 		description,
 		endpoint_url,
 		is_public,
@@ -202,7 +203,7 @@
 </script>
 
 <svelte:head>
-	<title>{description_short}</title>
+	<title>BEIS indicators - {description_short}</title>
 </svelte:head>
 
 <div class='container'>
@@ -348,6 +349,7 @@
 			{api_type}
 			{auth_provider}
 			{data_date}
+			{description_long}
 			{endpoint_url}
 			{is_public}
 			{query}


### PR DESCRIPTION
Closes #273

Adds the long dscription to the modal rather than to the header:

<img width="1270" alt="Screenshot 2020-08-20 at 19 13 10" src="https://user-images.githubusercontent.com/1309648/90809469-6ec03800-e319-11ea-8e3f-33ee12b2376d.png">
