### PR TITLE
Renaming the description* fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 - Update Svizzle packages (#364)
 - Update the color scale to blue-yellow-red (#358)
 
+## Specs
+
+- Description* fields (#365)
+	- renamed `description_long` -> `description`
+	- renamed `description_short` -> `subtitle`
+	- renamed `description` -> `title`
+	- removed `schema.value.description`
 
 # 0.0.12
 

--- a/ds/data/processed/aps/aps_econ_active_stem_associate_profs_data.lep.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_associate_profs_data.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Associated STEM professionals
-description: Number of Science, Research, Engineering and Technology associated professionals by LEP regions.
+subtitle: Associated STEM professionals
+title: Number of Science, Research, Engineering and Technology associated professionals by LEP regions.
 endpoint_url: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1925185537,1925185575,1925185538...1925185543,1925185572,1925185544,1925185570,1925185545,1925185577,1925185553,1925185547...1925185549,1925185571,1925185569,1925185551,1925185552,1925185554,1925185558,1925185555...1925185557,1925185559,1925185560,1925185550,1925185576,1925185562,1925185573,1925185563...192518556&date=latestMINUS25,latestMINUS21,latestMINUS17,latestMINUS13,latestMINUS9,latestMINUS5&cell=404882177,404883201&measures=20100,20701
 framework_group: public_rnd_capability
 is_experimental: False
@@ -15,7 +15,6 @@ schema:
   nuts_year_spec:
     type: LepRegion.lep_year_spec
   value:
-    description: Number of Science, Research, Engineering and Technology associated professionals.
     id: aps_econ_active_stem_associate_profs_data
     label: Frequency
     data_type: int

--- a/ds/data/processed/aps/aps_econ_active_stem_associate_profs_data.nuts2.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_associate_profs_data.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Associated STEM professionals
-description: Number of Science, Research, Engineering and Technology associated professionals by NUTS 2 regions.
+subtitle: Associated STEM professionals
+title: Number of Science, Research, Engineering and Technology associated professionals by NUTS 2 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&cell=404882177,404883201&measures=20100,20701,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&cell=404882177,404883201&measures=20100,20701,
@@ -20,7 +20,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Number of Science, Research, Engineering and Technology associated professionals.
     id: aps_econ_active_stem_associate_profs_data
     label: Frequency
     data_type: int

--- a/ds/data/processed/aps/aps_econ_active_stem_associate_profs_data.nuts3.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_associate_profs_data.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Associated STEM professionals
-description: Number of Science, Research, Engineering and Technology associated professionals by NUTS 3 regions.
+subtitle: Associated STEM professionals
+title: Number of Science, Research, Engineering and Technology associated professionals by NUTS 3 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1912602625...1912602758&date=latestMINUS27,latestMINUS23,latestMINUS19&cell=404882177,404883201&measures=20100,20701,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1883242497...1883242664&date=latestMINUS15,latestMINUS11,latestMINUS7&cell=404882177,404883201&measures=20100,20701,
@@ -20,7 +20,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Number of Science, Research, Engineering and Technology associated professionals.
     id: aps_econ_active_stem_associate_profs_data
     label: Frequency
     data_type: int

--- a/ds/data/processed/aps/aps_econ_active_stem_density_data.lep.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_density_data.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: STEM employee density
-description: Percentage of population employed in science, research, engineering and technology professional by LEP regions.
+subtitle: STEM employee density
+title: Percentage of population employed in science, research, engineering and technology professional by LEP regions.
 endpoint_url: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1925185537,1925185575,1925185538...1925185543,1925185572,1925185544,1925185570,1925185545,1925185577,1925185553,1925185547...1925185549,1925185571,1925185569,1925185551,1925185552,1925185554,1925185558,1925185555...1925185557,1925185559,1925185560,1925185550,1925185576,1925185562,1925185573,1925185563...192518556&date=latestMINUS25,latestMINUS21,latestMINUS17,latestMINUS13,latestMINUS9,latestMINUS5&variable=1543&measures=20599,21001,21002,21003
 framework_group: business_rnd_capacity
 is_experimental: False
@@ -15,7 +15,6 @@ schema:
   nuts_year_spec:
     type: LepRegion.lep_year_spec
   value:
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_econ_active_stem_density_data
     label: Percentage

--- a/ds/data/processed/aps/aps_econ_active_stem_density_data.nuts2.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_density_data.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: STEM employee density
-description: Percentage of population employed in science, research, engineering and technology professional by NUTS 2 regions.
+subtitle: STEM employee density
+title: Percentage of population employed in science, research, engineering and technology professional by NUTS 2 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=1543&measures=20599,21001,21002,21003,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=1543&measures=20599,21001,21002,21003,
@@ -20,7 +20,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_econ_active_stem_density_data
     label: Percentage

--- a/ds/data/processed/aps/aps_econ_active_stem_density_data.nuts3.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_density_data.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: STEM employee density
-description: Percentage of population employed in science, research, engineering and technology professional by NUTS 3 regions.
+subtitle: STEM employee density
+title: Percentage of population employed in science, research, engineering and technology professional by NUTS 3 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1912602625...1912602758&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=1543&measures=20599,21001,21002,21003,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1883242497...1883242664&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=1543&measures=20599,21001,21002,21003,
@@ -21,7 +21,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: float
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_econ_active_stem_density_data
     label: Percentage

--- a/ds/data/processed/aps/aps_econ_active_stem_profs_data.lep.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_profs_data.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: STEM professionals
-description: Number of Science, Research, Engineering and Technology professionals by LEP regions.
+subtitle: STEM professionals
+title: Number of Science, Research, Engineering and Technology professionals by LEP regions.
 endpoint_url: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1925185537,1925185575,1925185538...1925185543,1925185572,1925185544,1925185570,1925185545,1925185577,1925185553,1925185547...1925185549,1925185571,1925185569,1925185551,1925185552,1925185554,1925185558,1925185555...1925185557,1925185559,1925185560,1925185550,1925185576,1925185562,1925185573,1925185563...192518556&date=latestMINUS25,latestMINUS21,latestMINUS17,latestMINUS13,latestMINUS9,latestMINUS5&cell=404882177,404883201&measures=20100,20701
 framework_group: public_rnd_capability
 is_experimental: False
@@ -15,7 +15,6 @@ schema:
   nuts_year_spec:
     type: LepRegion.lep_year_spec
   value:
-    description: Number of Science, Research, Engineering and Technology professionals.
     id: aps_econ_active_stem_profs_data
     label: Frequency
     data_type: int

--- a/ds/data/processed/aps/aps_econ_active_stem_profs_data.nuts2.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_profs_data.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: STEM professionals
-description: Number of Science, Research, Engineering and Technology professionals by NUTS 2 regions.
+subtitle: STEM professionals
+title: Number of Science, Research, Engineering and Technology professionals by NUTS 2 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&cell=404882177,404883201&measures=20100,20701,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&cell=404882177,404883201&measures=20100,20701,
@@ -20,7 +20,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Number of Science, Research, Engineering and Technology professionals.
     id: aps_econ_active_stem_profs_data
     label: Frequency
     data_type: int

--- a/ds/data/processed/aps/aps_econ_active_stem_profs_data.nuts3.yaml
+++ b/ds/data/processed/aps/aps_econ_active_stem_profs_data.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: STEM professionals
-description: Number of Science, Research, Engineering and Technology professionals by NUTS 3 regions.
+subtitle: STEM professionals
+title: Number of Science, Research, Engineering and Technology professionals by NUTS 3 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1912602625...1912602758&date=latestMINUS27,latestMINUS23,latestMINUS19&cell=404882177,404883201&measures=20100,20701,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1883242497...1883242664&date=latestMINUS15,latestMINUS11,latestMINUS7&cell=404882177,404883201&measures=20100,20701,
@@ -20,7 +20,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Number of Science, Research, Engineering and Technology professionals.
     id: aps_econ_active_stem_profs_data
     label: Frequency
     data_type: int

--- a/ds/data/processed/aps/aps_nvq4_education_data.lep.yaml
+++ b/ds/data/processed/aps/aps_nvq4_education_data.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Economically active in professionals
-description: Percentage of economically active persons in professional occupations by LEP regions.
+subtitle: Economically active in professionals
+title: Percentage of economically active persons in professional occupations by LEP regions.
 endpoint_url: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1925185537,1925185575,1925185538...1925185543,1925185572,1925185544,1925185570,1925185545,1925185577,1925185553,1925185547...1925185549,1925185571,1925185569,1925185551,1925185552,1925185554,1925185558,1925185555...1925185557,1925185559,1925185560,1925185550,1925185576,1925185562,1925185573,1925185563...192518556&date=latestMINUS25,latestMINUS21,latestMINUS17,latestMINUS13,latestMINUS9,latestMINUS5&variable=353&measures=20599,21001,21002,21003
 framework_group: public_rnd_capability
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
     type: LepRegion.lep_year_spec
   value:
     data_type: float
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_nvq4_education_data
     label: Percentage

--- a/ds/data/processed/aps/aps_nvq4_education_data.nuts2.yaml
+++ b/ds/data/processed/aps/aps_nvq4_education_data.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Economically active in professionals
-description: Percentage of economically active persons in professional occupations by NUTS 2 regions.
+subtitle: Economically active in professionals
+title: Percentage of economically active persons in professional occupations by NUTS 2 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=353&measures=20599,21001,21002,21003,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=353&measures=20599,21001,21002,21003,
@@ -21,7 +21,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: float
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_nvq4_education_data
     label: Percentage

--- a/ds/data/processed/aps/aps_nvq4_education_data.nuts3.yaml
+++ b/ds/data/processed/aps/aps_nvq4_education_data.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Economically active in professionals
-description: Percentage of economically active persons in professional occupations by NUTS 3 regions.
+subtitle: Economically active in professionals
+title: Percentage of economically active persons in professional occupations by NUTS 3 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1912602625...1912602758&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=353&measures=20599,21001,21002,21003,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1883242497...1883242664&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=353&measures=20599,21001,21002,21003,
@@ -21,7 +21,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: float
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_nvq4_education_data
     label: Percentage

--- a/ds/data/processed/aps/aps_pro_occupations_data.lep.yaml
+++ b/ds/data/processed/aps/aps_pro_occupations_data.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Professional occupations employment
-description: Percentage of population employed in professional occupations by LEP regions.
+subtitle: Professional occupations employment
+title: Percentage of population employed in professional occupations by LEP regions.
 endpoint_url: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1925185537,1925185575,1925185538...1925185543,1925185572,1925185544,1925185570,1925185545,1925185577,1925185553,1925185547...1925185549,1925185571,1925185569,1925185551,1925185552,1925185554,1925185558,1925185555...1925185557,1925185559,1925185560,1925185550,1925185576,1925185562,1925185573,1925185563...1925185568&date=latestMINUS25,latestMINUS21,latestMINUS17,latestMINUS13,latestMINUS9,latestMINUS5&variable=1533&measures=20599,21001,21002,21003
 framework_group: public_rnd_capability
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
     type: LepRegion.lep_year_spec
   value:
     data_type: float
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_pro_occupations_data
     label: Percentage

--- a/ds/data/processed/aps/aps_pro_occupations_data.nuts2.yaml
+++ b/ds/data/processed/aps/aps_pro_occupations_data.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Professional occupations employment
-description: Percentage of population employed in professional occupations by NUTS 2 regions.
+subtitle: Professional occupations employment
+title: Percentage of population employed in professional occupations by NUTS 2 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=1533&measures=20599,21001,21002,21003,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=1533&measures=20599,21001,21002,21003,
@@ -21,7 +21,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: float
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_pro_occupations_data
     label: Percentage

--- a/ds/data/processed/aps/aps_pro_occupations_data.nuts3.yaml
+++ b/ds/data/processed/aps/aps_pro_occupations_data.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: FETCH
-description_short: Professional occupations employment
-description: Percentage of population employed in professional occupations by NUTS 3 regions.
+subtitle: Professional occupations employment
+title: Percentage of population employed in professional occupations by NUTS 3 regions.
 endpoint_url:
   2010: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1912602625...1912602758&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=1533&measures=20599,21001,21002,21003,
   2013: https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1883242497...1883242664&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=1533&measures=20599,21001,21002,21003,
@@ -21,7 +21,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: float
-    description: Percentage of population employed in professional occupations.
     format: .1f
     id: aps_pro_occupations_data
     label: Percentage

--- a/ds/data/processed/broadband/broadband_download_speed_data.lep.yaml
+++ b/ds/data/processed/broadband/broadband_download_speed_data.lep.yaml
@@ -1,6 +1,6 @@
 api_type: FETCH
-description_short: Broadband speed
-description: Broadband download speed by LEP regions.
+subtitle: Broadband speed
+title: Broadband download speed by LEP regions.
 endpoint_url:
   2014: https://webarchive.nationalarchives.gov.uk/20160703065525/http://www.ofcom.org.uk/static/research/ir/Fixed_postcode.zip
   2015: http://www.ofcom.org.uk/static/research/connected-nations2015/Fixed_Postcode_2015.zip
@@ -21,7 +21,6 @@ schema:
   nuts_year_spec:
     type: LepRegion.lep_year_spec
   value:
-    description: Broadband download speed.
     format: .3f
     id: broadband_download_speed_data
     label: Download Speed

--- a/ds/data/processed/broadband/broadband_download_speed_data.nuts2.yaml
+++ b/ds/data/processed/broadband/broadband_download_speed_data.nuts2.yaml
@@ -1,6 +1,6 @@
 api_type: FETCH
-description_short: Broadband speed
-description: Broadband download speed by NUTS 2 regions.
+subtitle: Broadband speed
+title: Broadband download speed by NUTS 2 regions.
 endpoint_url:
   2010: https://webarchive.nationalarchives.gov.uk/20160703065525/http://www.ofcom.org.uk/static/research/ir/Fixed_postcode.zip
   2013:
@@ -24,7 +24,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Broadband download speed.
     format: .3f
     id: broadband_download_speed_data
     label: Download Speed

--- a/ds/data/processed/broadband/broadband_download_speed_data.nuts3.yaml
+++ b/ds/data/processed/broadband/broadband_download_speed_data.nuts3.yaml
@@ -1,6 +1,6 @@
 api_type: FETCH
-description_short: Broadband speed
-description: Broadband download speed by NUTS 3 regions.
+subtitle: Broadband speed
+title: Broadband download speed by NUTS 3 regions.
 endpoint_url:
   2010: https://webarchive.nationalarchives.gov.uk/20160703065525/http://www.ofcom.org.uk/static/research/ir/Fixed_postcode.zip
   2013:
@@ -24,7 +24,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Broadband download speed.
     format: .3f
     id: broadband_download_speed_data
     label: Download Speed

--- a/ds/data/processed/cordis/cordis_funding.lep.yaml
+++ b/ds/data/processed/cordis/cordis_funding.lep.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://data.europa.eu/euodp/en/data/dataset/cordisH2020projects
 api_type: FETCH
 data_date: 20200909
-description_long: Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.
-description_short: Horizon 2020 funding
-description: Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.
+description: Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.
+subtitle: Horizon 2020 funding
+title: Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.
 endpoint_url:
   H2020 projects: https://cordis.europa.eu/data/cordis-h2020projects-xml.zip
   H2020 project descriptions: https://cordis.europa.eu/data/cordis-h2020projects.csv
@@ -20,7 +20,6 @@ schema:
     type: LepRegion.lep_year_spec # change this key to `LepRegion.lep_year_spec` or `LepRegion.lep_year_spec`
   value:
     data_type: int
-    description: total Horizon 2020 funding
     format: ','
     id: cordis_funding
     label: Total Funding

--- a/ds/data/processed/cordis/cordis_funding.nuts2.yaml
+++ b/ds/data/processed/cordis/cordis_funding.nuts2.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://data.europa.eu/euodp/en/data/dataset/cordisH2020projects
 api_type: FETCH
 data_date: 20200909
-description_long: Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.
-description_short: Horizon 2020 funding
-description: Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.
+description: Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.
+subtitle: Horizon 2020 funding
+title: Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.
 endpoint_url:
   H2020 projects: https://cordis.europa.eu/data/cordis-h2020projects-xml.zip
   H2020 project descriptions: https://cordis.europa.eu/data/cordis-h2020projects.csv
@@ -21,7 +21,6 @@ schema:
     type: NutsRegion.nuts_year_spec # change this key to `NutsRegion.nuts_year_spec` or `LepRegion.lep_year_spec`
   value:
     data_type: int
-    description: total Horizon 2020 funding
     format: ','
     id: cordis_funding
     label: Total Funding

--- a/ds/data/processed/cordis/cordis_funding.nuts3.yaml
+++ b/ds/data/processed/cordis/cordis_funding.nuts3.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://data.europa.eu/euodp/en/data/dataset/cordisH2020projects
 api_type: FETCH
 data_date: 20200909
-description_long: Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.
-description_short: Horizon 2020 funding
-description: Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.
+description: Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.
+subtitle: Horizon 2020 funding
+title: Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.
 endpoint_url:
   H2020 project: https://cordis.europa.eu/data/cordis-h2020projects-xml.zip
   H2020 project descriptions: https://cordis.europa.eu/data/cordis-h2020projects.csv
@@ -21,7 +21,6 @@ schema:
     type: NutsRegion.nuts_year_spec # change this key to `NutsRegion.nuts_year_spec` or `LepRegion.lep_year_spec`
   value:
     data_type: int
-    description: total Horizon 2020 funding
     format: ','
     id: cordis_funding
     label: Total Funding

--- a/ds/data/processed/crunchbase/companies_founded.lep.yaml
+++ b/ds/data/processed/crunchbase/companies_founded.lep.yaml
@@ -1,30 +1,29 @@
 api_type: MySQL
-auth_provider: Nesta 
+auth_provider: Nesta
 data_date: 20200922
-description_long: 'The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.'
-description_short: Total tech companies founded
-description: The total numer of technology companies founded according to Crunchbase.
-framework_group: business_rnd_capacity 
+description: 'The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.'
+subtitle: Total tech companies founded
+title: The total numer of technology companies founded according to Crunchbase.
+framework_group: business_rnd_capacity
 is_experimental: True
 is_public: False
-order: [year, lep_id, lep_year_spec, value.id] 
+order: [year, lep_id, lep_year_spec, value.id]
 region:
-  type: LepRegion 
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  type: LepRegion
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Total number of technology companies founded.
     id: companies_founded
     label: Number of companies founded
   year:
     data_type: int
     label: Year
-source_name: Crunchbase 
-source_url: https://crunchbase.com/ 
+source_name: Crunchbase
+source_url: https://crunchbase.com/
 warning: Crunchbase is not a comprehensive survey of all companies that have been founded and its coverage varies from place to place.

--- a/ds/data/processed/crunchbase/companies_founded.nuts2.yaml
+++ b/ds/data/processed/crunchbase/companies_founded.nuts2.yaml
@@ -1,31 +1,30 @@
 api_type: MySQL
-auth_provider: Nesta 
+auth_provider: Nesta
 data_date: 20200922
-description_long: 'The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.'
-description_short: Total tech companies founded
-description: The total numer of technology companies founded according to Crunchbase.
-framework_group: business_rnd_capacity 
+description: 'The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.'
+subtitle: Total tech companies founded
+title: The total numer of technology companies founded according to Crunchbase.
+framework_group: business_rnd_capacity
 is_experimental: True
 is_public: False
-order: [year, nuts_id, nuts_year_spec, value.id] 
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
-  type: NutsRegion 
+  type: NutsRegion
   level: 2
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Total number of technology companies founded.
     id: companies_founded
     label: Number of companies founded
   year:
     data_type: int
     label: Year
-source_name: Crunchbase 
-source_url: https://crunchbase.com/ 
+source_name: Crunchbase
+source_url: https://crunchbase.com/
 warning: Crunchbase is not a comprehensive survey of all companies that have been founded and its coverage varies from place to place.

--- a/ds/data/processed/crunchbase/companies_founded.nuts3.yaml
+++ b/ds/data/processed/crunchbase/companies_founded.nuts3.yaml
@@ -1,31 +1,30 @@
 api_type: MySQL
-auth_provider: Nesta 
+auth_provider: Nesta
 data_date: 20200922
-description_long: 'The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.'
-description_short: Total tech companies founded
-description: The total numer of technology companies founded according to Crunchbase.
-framework_group: business_rnd_capacity 
+description: 'The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.'
+subtitle: Total tech companies founded
+title: The total numer of technology companies founded according to Crunchbase.
+framework_group: business_rnd_capacity
 is_experimental: True
 is_public: False
-order: [year, nuts_id, nuts_year_spec, value.id] 
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
-  type: NutsRegion 
+  type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Total number of technology companies founded.
     id: companies_founded
     label: Number of companies founded
   year:
     data_type: int
     label: Year
-source_name: Crunchbase 
-source_url: https://crunchbase.com/ 
+source_name: Crunchbase
+source_url: https://crunchbase.com/
 warning: Crunchbase is not a comprehensive survey of all companies that have been founded and its coverage varies from place to place.

--- a/ds/data/processed/crunchbase/gbp_venture_capital_received.yaml
+++ b/ds/data/processed/crunchbase/gbp_venture_capital_received.yaml
@@ -2,8 +2,8 @@ api_doc_url: https://github.com/nestauk/data_getters#crunchbase (schema here- ht
 api_type: FETCH
 auth_provider: Nesta
 data_date: 20200218
-description_short: Venture capital investment
-description: Level of venture capital investment in ventures based on a region based on data from CrunchBase. A small number of deals have been converted to GBP at the date when they were announced.
+subtitle: Venture capital investment
+title: Level of venture capital investment in ventures based on a region based on data from CrunchBase. A small number of deals have been converted to GBP at the date when they were announced.
 endpoint_url: https://crunchbase-export.s3.eu-west-2.amazonaws.com/organizations.csv
 framework_group: business_rnd_capacity
 is_experimental: True
@@ -20,7 +20,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total amount of venture capital invested in organisations in the location
     format: ','
     id: gbp_venture_capital_received
     label: Venture capital investment received

--- a/ds/data/processed/defra/air_pollution_mean_pm10.lep.yaml
+++ b/ds/data/processed/defra/air_pollution_mean_pm10.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://uk-air.defra.gov.uk/data/pcm-data
 api_type: FETCH
-description_short: Mean PM10 particulate background pollution
-description: Mean PM10 particulate background pollution data for LEP regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.
+subtitle: Mean PM10 particulate background pollution
+title: Mean PM10 particulate background pollution data for LEP regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.
 endpoint_url:
   2007: https://uk-air.defra.gov.uk/datastore/pcm/mappm102007g.csv
   2008: https://uk-air.defra.gov.uk/datastore/pcm/mappm102008g.csv
@@ -27,7 +27,6 @@ schema:
   lep_year_spec:
     type: LepRegion.year_spec
   value:
-    description: mean pm10 particulate pollution value
     format: .2f
     id: air_pollution_mean_pm10
     label: Mean PM10 Pollution

--- a/ds/data/processed/defra/air_pollution_mean_pm10.nuts2.yaml
+++ b/ds/data/processed/defra/air_pollution_mean_pm10.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://uk-air.defra.gov.uk/data/pcm-data
 api_type: FETCH
-description_short: Mean PM10 particulate background pollution
-description: Mean PM10 particulate background pollution data at NUTS 2 regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.
+subtitle: Mean PM10 particulate background pollution
+title: Mean PM10 particulate background pollution data at NUTS 2 regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.
 endpoint_url:
   2007: https://uk-air.defra.gov.uk/datastore/pcm/mappm102007g.csv
   2008: https://uk-air.defra.gov.uk/datastore/pcm/mappm102008g.csv
@@ -29,7 +29,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.year_spec
   value:
-    description: mean pm10 particulate pollution value
     format: .2f
     id: air_pollution_mean_pm10
     label: Mean PM10 Pollution

--- a/ds/data/processed/defra/air_pollution_mean_pm10.nuts3.yaml
+++ b/ds/data/processed/defra/air_pollution_mean_pm10.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://uk-air.defra.gov.uk/data/pcm-data
 api_type: FETCH
-description_short: Mean PM10 particulate background pollution
-description: Mean PM10 particulate background pollution data at NUTS 3 regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.
+subtitle: Mean PM10 particulate background pollution
+title: Mean PM10 particulate background pollution data at NUTS 3 regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.
 endpoint_url:
   2007: https://uk-air.defra.gov.uk/datastore/pcm/mappm102007g.csv
   2008: https://uk-air.defra.gov.uk/datastore/pcm/mappm102008g.csv
@@ -29,7 +29,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.year_spec
   value:
-    description: mean pm10 particulate pollution value
     format: .2f
     id: air_pollution_mean_pm10
     label: Mean PM10 Pollution

--- a/ds/data/processed/eurostat/epo_patent_applications.nuts2.yaml
+++ b/ds/data/processed/eurostat/epo_patent_applications.nuts2.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/pat_esms.htm
 api_type: FETCH
 data_date: 20200818
-description_long: Patent applications are a proxy for inventions. We focus on applications to the European Patent Office (EPO). The year is the priority year for the patent i.e. the first year that the patent was filed with any patenting authority. There are significant lags between patent applications and publication, which explains the low timeliness of the data.
-description_short: Patent applications (EPO)
-description: Count of patent applications normalised by the number of applicants in a patent if there are more than one
+description: Patent applications are a proxy for inventions. We focus on applications to the European Patent Office (EPO). The year is the priority year for the patent i.e. the first year that the patent was filed with any patenting authority. There are significant lags between patent applications and publication, which explains the low timeliness of the data.
+subtitle: Patent applications (EPO)
+title: Count of patent applications normalised by the number of applicants in a patent if there are more than one
 endpoint_url: https://appsso.eurostat.ec.europa.eu/nui/show.do?dataset=pat_ep_rtot&lang=en
 framework_group: knowledge_exchange
 is_experimental: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Count of patent applications
     id: epo_patent_applications
     label: Patent applications
   year:

--- a/ds/data/processed/eurostat/epo_patent_applications.nuts3.yaml
+++ b/ds/data/processed/eurostat/epo_patent_applications.nuts3.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/pat_esms.htm
 api_type: FETCH
 data_date: 20200818
-description_long: Patent applications are a proxy for inventions. We focus on applications to the European Patent Office (EPO). The year is the priority year for the patent i.e. the first year that the patent was filed with any patenting authority. There are significant lags between patent applications and publication, which explains the low timeliness of the data.
-description_short: Patent applications (EPO)
-description: Count of patent applications normalised by the number of applicants in a patent if there are more than one
+description: Patent applications are a proxy for inventions. We focus on applications to the European Patent Office (EPO). The year is the priority year for the patent i.e. the first year that the patent was filed with any patenting authority. There are significant lags between patent applications and publication, which explains the low timeliness of the data.
+subtitle: Patent applications (EPO)
+title: Count of patent applications normalised by the number of applicants in a patent if there are more than one
 endpoint_url: https://appsso.eurostat.ec.europa.eu/nui/show.do?dataset=pat_ep_rtot&lang=en
 framework_group: knowledge_exchange
 is_experimental: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Count of patent applications
     id: epo_patent_applications
     label: Patent applications
   year:

--- a/ds/data/processed/eurostat/eu_trademark_applications.nuts2.yaml
+++ b/ds/data/processed/eurostat/eu_trademark_applications.nuts2.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/ipr_t_esms.htm
 api_type: FETCH
 data_date: 20200818
-description_long: Trademark applications are a proxy for commercialisation. This indiator captures trademark registrations in the EU.
-description_short: Trademark
-description: Count of trademark applications
+description: Trademark applications are a proxy for commercialisation. This indiator captures trademark registrations in the EU.
+subtitle: Trademark
+title: Count of trademark applications
 endpoint_url: https://appsso.eurostat.ec.europa.eu/nui/show.do?dataset=ipr_ta_reg&lang=en
 framework_group: knowledge_exchange
 is_experimental: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Count of trademark applications
     id: eu_trademark_applications
     label: Trademark applications
   year:

--- a/ds/data/processed/eurostat/eu_trademark_applications.nuts3.yaml
+++ b/ds/data/processed/eurostat/eu_trademark_applications.nuts3.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/ipr_t_esms.htm
 api_type: FETCH
 data_date: 20200818
-description_long: Trademark applications are a proxy for commercialisation. This indiator captures trademark registrations in the EU.
-description_short: Trademark
-description: Count of trademark applications
+description: Trademark applications are a proxy for commercialisation. This indiator captures trademark registrations in the EU.
+subtitle: Trademark
+title: Count of trademark applications
 endpoint_url: https://appsso.eurostat.ec.europa.eu/nui/show.do?dataset=ipr_ta_reg&lang=en
 framework_group: knowledge_exchange
 is_experimental: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Count of trademark applications
     id: eu_trademark_applications
     label: Trademark applications
   year:

--- a/ds/data/processed/eurostat/eurostat_berd_data.yaml
+++ b/ds/data/processed/eurostat/eurostat_berd_data.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
-description_short: Business enterprise R&D
-description: Business enterprise research & development (R&D) expenditure by NUTS 2 regions.
+subtitle: Business enterprise R&D
+title: Business enterprise research & development (R&D) expenditure by NUTS 2 regions.
 endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=6&sectperf=BES&unit=MIO_EUR
 framework_group: business_rnd_capacity
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: business enterprise R&D expenditure in euros (to the nearest 1000)
     format: ','
     id: eurostat_berd_data
     label: Expenditure (to nearest 1000)

--- a/ds/data/processed/eurostat/eurostat_gov_rd_workforce_data.yaml
+++ b/ds/data/processed/eurostat/eurostat_gov_rd_workforce_data.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
-description_short: Government R&D
-description: Government performed research & development (R&D) expenditure by NUTS 2 regions.
+subtitle: Government R&D
+title: Government performed research & development (R&D) expenditure by NUTS 2 regions.
 endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=2&sectperf=GOV&unit=MIO_EUR
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: government performed R&D expenditure in euros (to the nearest 1000)
     format: ','
     id: eurostat_gov_rd_workforce_data
     label: Expenditure (to nearest 1000)

--- a/ds/data/processed/eurostat/eurostat_higher_ed_rd_workforce_data.yaml
+++ b/ds/data/processed/eurostat/eurostat_higher_ed_rd_workforce_data.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
-description_short: Higher Edu R&D
-description: Higher education sector enterprise research & development (R&D) expenditure by NUTS 2 regions.
+subtitle: Higher Edu R&D
+title: Higher education sector enterprise research & development (R&D) expenditure by NUTS 2 regions.
 endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=6&sectperf=HES&unit=MIO_EUR'
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Higher education sector R&D expenditure in euros (to the nearest 1000)
     format: ','
     id: eurostat_higher_ed_rd_workforce_data
     label: Expenditure (to nearest 1000)

--- a/ds/data/processed/eurostat/eurostat_private_non_profit_rd_workforce_data.yaml
+++ b/ds/data/processed/eurostat/eurostat_private_non_profit_rd_workforce_data.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
-description_short: Private non-profit R&D
-description: Private non-profit sector enterprise research & development (R&D) expenditure by NUTS 2 regions.
+subtitle: Private non-profit R&D
+title: Private non-profit sector enterprise research & development (R&D) expenditure by NUTS 2 regions.
 endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=6&sectperf=PNP&unit=MIO_EUR'
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Private non-profit sector R&D expenditure in euros (to the nearest 1000)
     format: ','
     id: eurostat_private_non_profit_rd_workforce_data
     label: Expenditure (to nearest 1000)

--- a/ds/data/processed/eurostat/eurostat_private_rd_fte_workforce_data.yaml
+++ b/ds/data/processed/eurostat/eurostat_private_rd_fte_workforce_data.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
-description_short: FTE of R&D workforce
-description: Full time equivalent (FTE) of private sector research & development (R&D) workforce-  by NUTS 2 regions.
+subtitle: FTE of R&D workforce
+title: Full time equivalent (FTE) of private sector research & development (R&D) workforce-  by NUTS 2 regions.
 endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_p_persreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=1&sex=T&sectperf=BES&prof_pos=TOTAL&unit=FTE
 framework_group: business_rnd_capacity
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Full time equivalent of workforce
     format: .2f
     id: eurostat_private_rd_fte_workforce_data
     label: Full Time Equivalent

--- a/ds/data/processed/eurostat/eurostat_private_rd_headcount_workforce_data.yaml
+++ b/ds/data/processed/eurostat/eurostat_private_rd_headcount_workforce_data.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
-description_short: HC of R&D workforce
-description: Head count (HC) OF private sector research & development (R&D) workforce by NUTS 2 regions.
+subtitle: HC of R&D workforce
+title: Head count (HC) OF private sector research & development (R&D) workforce by NUTS 2 regions.
 endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_p_persreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=1&sex=T&sectperf=BES&prof_pos=TOTAL&unit=HC
 framework_group: business_rnd_capacity
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Head count of workforce
     id: eurostat_private_rd_headcount_workforce_data
     label: Head count
     data_type: int

--- a/ds/data/processed/gtr/total_gtr_projects_stem.yaml
+++ b/ds/data/processed/gtr/total_gtr_projects_stem.yaml
@@ -2,8 +2,8 @@ api_doc_url: https://gtr.ukri.org/resources/GtR-2-API-v1.7.4.pdf
 api_type: FETCH
 auth_provider: Nesta
 data_date: 20200222
-description_short: STEM projects led by organisations in the region
-description: Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)
+subtitle: STEM projects led by organisations in the region
+title: Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)
 endpoint_url: https://s3.console.aws.amazon.com/s3/object/nesta-data-getters/17_9_2019_gtr_orgs.csv
 framework_group: public_rnd_capability
 is_experimental: True
@@ -20,7 +20,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.year_spec
   value:
-    description: Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)
     format: ','
     id: total_gtr_projects_stem
     label: Number of projects in STEM disciplines led by organisations in the region

--- a/ds/data/processed/gtr/total_ukri_funding.lep.yaml
+++ b/ds/data/processed/gtr/total_ukri_funding.lep.yaml
@@ -2,9 +2,9 @@ api_doc_url: https://gtr.ukri.org/resources/GtR-2-API-v1.7.4.pdf
 api_type: MySQL
 auth_provider: Nesta
 data_date: 20200910
-description_long: Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.
-description_short: Total funding (GBP) for research awarded by UKRI
-description: Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)
+description: Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.
+subtitle: Total funding (GBP) for research awarded by UKRI
+title: Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)
 framework_group: public_rnd_capability
 is_experimental: False
 is_public: False
@@ -18,7 +18,6 @@ schema:
     type: LepRegion.year_spec
   value:
     data_type: int
-    description: Total funding (GBP) for research awarded by UKRI
     format: ','
     id: total_ukri_funding
     label: Total Funding

--- a/ds/data/processed/gtr/total_ukri_funding.nuts2.yaml
+++ b/ds/data/processed/gtr/total_ukri_funding.nuts2.yaml
@@ -2,9 +2,9 @@ api_doc_url: https://gtr.ukri.org/resources/GtR-2-API-v1.7.4.pdf
 api_type: MySQL
 auth_provider: Nesta
 data_date: 20200910
-description_long: Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.
-description_short: Total funding (GBP) for research awarded by UKRI
-description: Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)
+description: Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.
+subtitle: Total funding (GBP) for research awarded by UKRI
+title: Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)
 framework_group: public_rnd_capability
 is_experimental: False
 is_public: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total funding (GBP) for research awarded by UKRI
     format: ','
     id: total_ukri_funding
     label: Total Funding

--- a/ds/data/processed/gtr/total_ukri_funding.nuts3.yaml
+++ b/ds/data/processed/gtr/total_ukri_funding.nuts3.yaml
@@ -2,9 +2,9 @@ api_doc_url: https://gtr.ukri.org/resources/GtR-2-API-v1.7.4.pdf
 api_type: MySQL
 auth_provider: Nesta
 data_date: 20200910
-description_long: Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.
-description_short: Total funding (GBP) for research awarded by UKRI
-description: Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)
+description: Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.
+subtitle: Total funding (GBP) for research awarded by UKRI
+title: Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)
 framework_group: public_rnd_capability
 is_experimental: False
 is_public: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total funding (GBP) for research awarded by UKRI
     format: ','
     id: total_ukri_funding
     label: Total Funding

--- a/ds/data/processed/hebci/ce_cpd_income.lep.yaml
+++ b/ds/data/processed/hebci/ce_cpd_income.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Income from continuing professional development and continuing education.
-description_short: Continuing professional development and education income
+data_date: 20200928
 description: Income from continuing professional development and continuing education.
+subtitle: Continuing professional development and education income
+title: Income from continuing professional development and continuing education.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Continuing professional development and education income
     id: ce_cpd_income
     label: Income
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ce_cpd_income.nuts2.yaml
+++ b/ds/data/processed/hebci/ce_cpd_income.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Income from continuing professional development and continuing education.
-description_short: Continuing professional development and education income
+data_date: 20200928
 description: Income from continuing professional development and continuing education.
+subtitle: Continuing professional development and education income
+title: Income from continuing professional development and continuing education.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 2
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Continuing professional development and education income
     id: ce_cpd_income
     label: Income
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ce_cpd_income.nuts3.yaml
+++ b/ds/data/processed/hebci/ce_cpd_income.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Income from continuing professional development and continuing education.
-description_short: Continuing professional development and education income
+data_date: 20200928
 description: Income from continuing professional development and continuing education.
+subtitle: Continuing professional development and education income
+title: Income from continuing professional development and continuing education.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 3
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Continuing professional development and education income
     id: ce_cpd_income
     label: Income
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ce_cpd_learner_days.lep.yaml
+++ b/ds/data/processed/hebci/ce_cpd_learner_days.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Number of continuing professional development and continuing education learner days
-description_short: Continuing professional development and education learner days
+data_date: 20200928
 description: Number of continuing professional development and continuing education learner days
+subtitle: Continuing professional development and education learner days
+title: Number of continuing professional development and continuing education learner days
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Continuing professional development and education learner days
     id: ce_cpd_learner_days
     label: Days
   year:
@@ -28,4 +27,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ce_cpd_learner_days.nuts2.yaml
+++ b/ds/data/processed/hebci/ce_cpd_learner_days.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Number of continuing professional development and continuing education learner days
-description_short: Continuing professional development and education learner days
+data_date: 20200928
 description: Number of continuing professional development and continuing education learner days
+subtitle: Continuing professional development and education learner days
+title: Number of continuing professional development and continuing education learner days
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 2
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Continuing professional development and education learner days
     id: ce_cpd_learner_days
     label: Days
   year:
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ce_cpd_learner_days.nuts3.yaml
+++ b/ds/data/processed/hebci/ce_cpd_learner_days.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Number of continuing professional development and continuing education learner days
-description_short: Continuing professional development and education learner days
+data_date: 20200928
 description: Number of continuing professional development and continuing education learner days
+subtitle: Continuing professional development and education learner days
+title: Number of continuing professional development and continuing education learner days
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 3
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Continuing professional development and education learner days
     id: ce_cpd_learner_days
     label: Days
   year:
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/collaborative_research_cash.lep.yaml
+++ b/ds/data/processed/hebci/collaborative_research_cash.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.
-description_short: Collaborative research funding
-description: Cash value of collaborations with non-academic parterns.  
+data_date: 20200924
+description: Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.
+subtitle: Collaborative research funding
+title: Cash value of collaborations with non-academic parterns.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-1.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Collaborative research funding
     id: collaborative_research_cash
     label: Collaborative research income
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/collaborative_research_cash.nuts2.yaml
+++ b/ds/data/processed/hebci/collaborative_research_cash.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.
-description_short: Collaborative research funding
-description: Cash value of collaborations with non-academic parterns.  
+data_date: 20200924
+description: Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.
+subtitle: Collaborative research funding
+title: Cash value of collaborations with non-academic parterns.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-1.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 2
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Collaborative research funding
     id: collaborative_research_cash
     label: Collaborative research income
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/collaborative_research_cash.nuts3.yaml
+++ b/ds/data/processed/hebci/collaborative_research_cash.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.
-description_short: Collaborative research funding
-description: Cash value of collaborations with non-academic parterns.  
+data_date: 20200924
+description: Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.
+subtitle: Collaborative research funding
+title: Cash value of collaborations with non-academic parterns.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-1.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 3
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Collaborative research funding
     id: collaborative_research_cash
     label: Collaborative research income
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/consultancy_facilities_non_sme.lep.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_non_sme.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to non-SME companies. 
-description_short: HE consultancy and facilities income from non-SME companies
-description: Income for higher education institutions from providing consultancy and facilities services to non-SME companies. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing consultancy and facilities services to non-SME companies.
+subtitle: HE consultancy and facilities income from non-SME companies
+title: Income for higher education institutions from providing consultancy and facilities services to non-SME companies.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_non_sme
     label: Income from consultancy and facilities
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/consultancy_facilities_non_sme.nuts2.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_non_sme.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to non-SME companies. 
-description_short: HE consultancy and facilities income from non-SME companies
-description: Income for higher education institutions from providing consultancy and facilities services to non-SME companies. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing consultancy and facilities services to non-SME companies.
+subtitle: HE consultancy and facilities income from non-SME companies
+title: Income for higher education institutions from providing consultancy and facilities services to non-SME companies.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 2
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_non_sme
     label: Income from consultancy and facilities
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/consultancy_facilities_non_sme.nuts3.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_non_sme.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to non-SME companies. 
-description_short: HE consultancy and facilities income from non-SME companies
-description: Income for higher education institutions from providing consultancy and facilities services to non-SME companies. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing consultancy and facilities services to non-SME companies.
+subtitle: HE consultancy and facilities income from non-SME companies
+title: Income for higher education institutions from providing consultancy and facilities services to non-SME companies.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_non_sme
     label: Income from consultancy and facilities
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/consultancy_facilities_public_third.lep.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_public_third.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations. 
-description_short: HE consultancy and facilities income from public and third sector organisations
-description: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations.
+subtitle: HE consultancy and facilities income from public and third sector organisations
+title: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_public_third
     label: Income from consultancy and facilities
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/consultancy_facilities_public_third.nuts2.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_public_third.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations. 
-description_short: HE consultancy and facilities income from public and third sector organisations
-description: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations.
+subtitle: HE consultancy and facilities income from public and third sector organisations
+title: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
-  level: 2 
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  level: 2
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_public_third
     label: Income from consultancy and facilities
     type: GBP

--- a/ds/data/processed/hebci/consultancy_facilities_public_third.nuts3.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_public_third.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations. 
-description_short: HE consultancy and facilities income from public and third sector organisations
-description: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations.
+subtitle: HE consultancy and facilities income from public and third sector organisations
+title: Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_public_third
     label: Income from consultancy and facilities
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/consultancy_facilities_sme.lep.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_sme.lep.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to SMEs. 
-description_short: HE consultancy and facilities income from SMEs
-description: Income for higher education institutions from providing consultancy and facilities services to SMEs
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing consultancy and facilities services to SMEs.
+subtitle: HE consultancy and facilities income from SMEs
+title: Income for higher education institutions from providing consultancy and facilities services to SMEs
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
   level: 2
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_sme
     label: Income from consultancy and facilities
     type: GBP

--- a/ds/data/processed/hebci/consultancy_facilities_sme.nuts2.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_sme.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to SMEs
-description_short: HE consultancy and facilities income from SMEs
+data_date: 20200924
 description: Income for higher education institutions from providing consultancy and facilities services to SMEs
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+subtitle: HE consultancy and facilities income from SMEs
+title: Income for higher education institutions from providing consultancy and facilities services to SMEs
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
-  level: 2 
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  level: 2
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_sme
     label: Income from consultancy and facilities
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/consultancy_facilities_sme.nuts3.yaml
+++ b/ds/data/processed/hebci/consultancy_facilities_sme.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing consultancy and facilities services to SMEs
-description_short: HE consultancy and facilities income from SMEs
+data_date: 20200924
 description: Income for higher education institutions from providing consultancy and facilities services to SMEs
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+subtitle: HE consultancy and facilities income from SMEs
+title: Income for higher education institutions from providing consultancy and facilities services to SMEs
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: consultancy_facilities_sme
     label: Income from consultancy and facilities
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_non_sme.lep.yaml
+++ b/ds/data/processed/hebci/contract_research_non_sme.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to non-SME companies. 
-description_short: HE contract research income from non-SME companies
-description: Income for higher education institutions from providing contract research services to non-SME companies. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to non-SME companies.
+subtitle: HE contract research income from non-SME companies
+title: Income for higher education institutions from providing contract research services to non-SME companies.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: contract_research_non_sme
     label: Income from contract research
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_non_sme.nuts2.yaml
+++ b/ds/data/processed/hebci/contract_research_non_sme.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to non-SME companies. 
-description_short: HE contract research income from non-SME companies
-description: Income for higher education institutions from providing contract research services to non-SME companies. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to non-SME companies.
+subtitle: HE contract research income from non-SME companies
+title: Income for higher education institutions from providing contract research services to non-SME companies.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
-  level: 2 
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  level: 2
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: contract_research_non_sme
     label: Income from contract research
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_non_sme.nuts3.yaml
+++ b/ds/data/processed/hebci/contract_research_non_sme.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to non-SME companies. 
-description_short: HE contract research income from non-SME companies
-description: Income for higher education institutions from providing contract research services to non-SME companies. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to non-SME companies.
+subtitle: HE contract research income from non-SME companies
+title: Income for higher education institutions from providing contract research services to non-SME companies.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: contract_research_non_sme
     label: Income from contract research
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_public_third.lep.yaml
+++ b/ds/data/processed/hebci/contract_research_public_third.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to public and third sector organisations. 
-description_short: HE contract research income from public and third sector organisations
-description: Income for higher education institutions from providing contract research services to public and third sector organisations
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to public and third sector organisations.
+subtitle: HE contract research income from public and third sector organisations
+title: Income for higher education institutions from providing contract research services to public and third sector organisations
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: contract_research_public_third
     label: Income from contract research
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_public_third.nuts2.yaml
+++ b/ds/data/processed/hebci/contract_research_public_third.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to public and third sector organisations. 
-description_short: HE contract research income from public and third sector organisations
-description: Income for higher education institutions from providing contract research services to public and third sector organisations
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to public and third sector organisations.
+subtitle: HE contract research income from public and third sector organisations
+title: Income for higher education institutions from providing contract research services to public and third sector organisations
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
-  level: 2 
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  level: 2
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: contract_research_public_third
     label: Income from contract research
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_public_third.nuts3.yaml
+++ b/ds/data/processed/hebci/contract_research_public_third.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to public and third sector organisations. 
-description_short: HE contract research income from public and third sector organisations
-description: Income for higher education institutions from providing contract research services to public and third sector organisations
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to public and third sector organisations.
+subtitle: HE contract research income from public and third sector organisations
+title: Income for higher education institutions from providing contract research services to public and third sector organisations
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
     id: contract_research_public_third
     label: Income from contract research
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_sme.lep.yaml
+++ b/ds/data/processed/hebci/contract_research_sme.lep.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to SMEs. 
-description_short: HE contract research income from SMEs
-description: Income for higher education institutions from providing contract research services to SMEs. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to SMEs.
+subtitle: HE contract research income from SMEs
+title: Income for higher education institutions from providing contract research services to SMEs.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Contract research income
-    id: contract_research_sme 
+    id: contract_research_sme
     label: Income from contract research
     type: GBP
   year:
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_sme.nuts2.yaml
+++ b/ds/data/processed/hebci/contract_research_sme.nuts2.yaml
@@ -1,28 +1,27 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to SMEs. 
-description_short: HE contract research income from SMEs
-description: Income for higher education institutions from providing contract research services to SMEs. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to SMEs.
+subtitle: HE contract research income from SMEs
+title: Income for higher education institutions from providing contract research services to SMEs.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
-  level: 2 
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  level: 2
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
-    id: contract_research_sme 
+    id: contract_research_sme
     label: Income from contract research
     type: GBP
   year:
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/contract_research_sme.nuts3.yaml
+++ b/ds/data/processed/hebci/contract_research_sme.nuts3.yaml
@@ -1,28 +1,27 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from providing contract research services to SMEs. 
-description_short: HE contract research income from SMEs
-description: Income for higher education institutions from providing contract research services to SMEs. 
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv 
+data_date: 20200924
+description: Income for higher education institutions from providing contract research services to SMEs.
+subtitle: HE contract research income from SMEs
+title: Income for higher education institutions from providing contract research services to SMEs.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Contract research income
-    id: contract_research_sme 
+    id: contract_research_sme
     label: Income from contract research
     type: GBP
   year:

--- a/ds/data/processed/hebci/gbp_turnover_per_active_spinoff.yaml
+++ b/ds/data/processed/hebci/gbp_turnover_per_active_spinoff.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.hesa.ac.uk/support/definitions/hebci
 api_type: FETCH
 data_date: 20202002
-description_short: Current turnover of active university spinoffs
-description: Total current turnover of active spinoffs involving local universities in academic year starting in year
+subtitle: Current turnover of active university spinoffs
+title: Total current turnover of active spinoffs involving local universities in academic year starting in year
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
@@ -18,7 +18,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Total current turnover of active spinoffs involving local universities in academic year starting in year
     format: ','
     id: gbp_turnover_per_active_spinoff
     label: Current turnover of active university spinoffs

--- a/ds/data/processed/hebci/graduate_startups.lep.yaml
+++ b/ds/data/processed/hebci/graduate_startups.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Number of active startups founded by higher education graduates.
-description_short: Active graduate startups
+data_date: 20200928
 description: Number of active startups founded by higher education graduates.
+subtitle: Active graduate startups
+title: Number of active startups founded by higher education graduates.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Active graduate startups
     id: graduate_startups
     label: Startups
   year:
@@ -28,4 +27,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/graduate_startups.nuts2.yaml
+++ b/ds/data/processed/hebci/graduate_startups.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Number of active startups founded by higher education graduates.
-description_short: Active graduate startups
+data_date: 20200928
 description: Number of active startups founded by higher education graduates.
+subtitle: Active graduate startups
+title: Number of active startups founded by higher education graduates.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 2
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Active graduate startups
     id: graduate_startups
     label: Startups
   year:
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/graduate_startups.nuts3.yaml
+++ b/ds/data/processed/hebci/graduate_startups.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Number of active startups founded by higher education graduates.
-description_short: Active graduate startups
+data_date: 20200928
 description: Number of active startups founded by higher education graduates.
+subtitle: Active graduate startups
+title: Number of active startups founded by higher education graduates.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 3
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Active graduate startups
     id: graduate_startups
     label: Startups
   year:
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ip_revenue.lep.yaml
+++ b/ds/data/processed/hebci/ip_revenue.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.
-description_short: HE intellectual property income
-description: Income from intellectual property by higher education providers.
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4d.csv 
+data_date: 20200924
+description: Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.
+subtitle: HE intellectual property income
+title: Income from intellectual property by higher education providers.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4d.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: HE intellectual property income
     id: ip_revenue
     label: Income
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ip_revenue.nuts2.yaml
+++ b/ds/data/processed/hebci/ip_revenue.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.
-description_short: HE intellectual property income
-description: Income from intellectual property by higher education providers.
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4d.csv 
+data_date: 20200924
+description: Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.
+subtitle: HE intellectual property income
+title: Income from intellectual property by higher education providers.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4d.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 2
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: HE intellectual property income
     id: ip_revenue
     label: Income
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/ip_revenue.nuts3.yaml
+++ b/ds/data/processed/hebci/ip_revenue.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200924 
-description_long: Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.
-description_short: HE intellectual property income
-description: Income from intellectual property by higher education providers.
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4d.csv 
+data_date: 20200924
+description: Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.
+subtitle: HE intellectual property income
+title: Income from intellectual property by higher education providers.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4d.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: HE intellectual property income
     id: ip_revenue
     label: Income
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/regeneration_development.lep.yaml
+++ b/ds/data/processed/hebci/regeneration_development.lep.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/business-community/regeneration
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\" The indicator values represent the sum of income from all public bodies.
-description_short: HE regeneration and development income 
-description: Income for higher education institutions from public regeneration and development programmes.
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-3.csv 
+data_date: 20200924
+description: Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\" The indicator values represent the sum of income from all public bodies.
+subtitle: HE regeneration and development income
+title: Income for higher education institutions from public regeneration and development programmes.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-3.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Regeneration and development income
-    id: regeneration_development 
+    id: regeneration_development
     label: Income from regeneration and development
     type: GBP
   year:

--- a/ds/data/processed/hebci/regeneration_development.nuts2.yaml
+++ b/ds/data/processed/hebci/regeneration_development.nuts2.yaml
@@ -1,28 +1,27 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/business-community/regeneration
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\" The indicator values represent the sum of income from all public bodies.
-description_short: HE regeneration and development income 
-description: Income for higher education institutions from public regeneration and development programmes.
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-3.csv 
+data_date: 20200924
+description: Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\" The indicator values represent the sum of income from all public bodies.
+subtitle: HE regeneration and development income
+title: Income for higher education institutions from public regeneration and development programmes.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-3.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
-  level: 2 
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  level: 2
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Regeneration and development income
-    id: regeneration_development 
+    id: regeneration_development
     label: Income from regeneration and development
     type: GBP
   year:

--- a/ds/data/processed/hebci/regeneration_development.nuts3.yaml
+++ b/ds/data/processed/hebci/regeneration_development.nuts3.yaml
@@ -1,28 +1,27 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/business-community/regeneration
 api_type: FETCH
-data_date: 20200924 
-description_long: Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\" The indicator values represent the sum of income from all public bodies.
-description_short: HE regeneration and development income 
-description: Income for higher education institutions from public regeneration and development programmes.
-endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-3.csv 
+data_date: 20200924
+description: Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\" The indicator values represent the sum of income from all public bodies.
+subtitle: HE regeneration and development income
+title: Income for higher education institutions from public regeneration and development programmes.
+endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-3.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   type: NutsRegion
   level: 3
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Regeneration and development income
-    id: regeneration_development 
+    id: regeneration_development
     label: Income from regeneration and development
     type: GBP
   year:

--- a/ds/data/processed/hebci/spinoff_investment.lep.yaml
+++ b/ds/data/processed/hebci/spinoff_investment.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
-description: Total external investment in all spin-off activities associated with higher education institutions.
-description_short: Investment in higher education spin-offs
+data_date: 20200928
+description: Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
+title: Total external investment in all spin-off activities associated with higher education institutions.
+subtitle: Investment in higher education spin-offs
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Investment in higher education spin-offs
     id: spinoff_investment
     label: Investment
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/spinoff_investment.nuts2.yaml
+++ b/ds/data/processed/hebci/spinoff_investment.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
-description: Total external investment in all spin-off activities associated with higher education institutions.
-description_short: Investment in higher education spin-offs
+data_date: 20200928
+description: Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
+title: Total external investment in all spin-off activities associated with higher education institutions.
+subtitle: Investment in higher education spin-offs
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 2
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Investment in higher education spin-offs
     id: spinoff_investment
     label: Investment
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/spinoff_investment.nuts3.yaml
+++ b/ds/data/processed/hebci/spinoff_investment.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
-description: Total external investment in all spin-off activities associated with higher education institutions.
-description_short: Investment in higher education spin-offs
+data_date: 20200928
+description: Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
+title: Total external investment in all spin-off activities associated with higher education institutions.
+subtitle: Investment in higher education spin-offs
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 3
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Investment in higher education spin-offs
     id: spinoff_investment
     label: Investment
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/spinoff_revenue.lep.yaml
+++ b/ds/data/processed/hebci/spinoff_revenue.lep.yaml
@@ -1,26 +1,25 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
-description_short: Total turnover of higher education spin-offs
-description: Total turnover of all spin-off activities associated with higher education institutions.
+data_date: 20200928
+description: Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
+subtitle: Total turnover of higher education spin-offs
+title: Total turnover of all spin-off activities associated with higher education institutions.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, lep_id, lep_year_spec, value.id] 
+is_public: True
+order: [year, lep_id, lep_year_spec, value.id]
 region:
   type: LepRegion
-  source_url: LepRegion.source_url 
-  source: LepRegion.source 
+  source_url: LepRegion.source_url
+  source: LepRegion.source
 schema:
-  lep_id: 
-    type: LepRegion.lep_id 
-  lep_year_spec: 
-    type: LepRegion.lep_year_spec 
+  lep_id:
+    type: LepRegion.lep_id
+  lep_year_spec:
+    type: LepRegion.lep_year_spec
   value:
     data_type: int
-    description: Total turnover of higher education spin-offs
     id: spinoff_revenue
     label: Turnover
     type: GBP
@@ -29,4 +28,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/spinoff_revenue.nuts2.yaml
+++ b/ds/data/processed/hebci/spinoff_revenue.nuts2.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
-description_short: Total turnover of higher education spin-offs
-description: Total turnover of all spin-off activities associated with higher education institutions.
+data_date: 20200928
+description: Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
+subtitle: Total turnover of higher education spin-offs
+title: Total turnover of all spin-off activities associated with higher education institutions.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 2
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Total turnover of higher education spin-offs
     id: spinoff_revenue
     label: Turnover
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hebci/spinoff_revenue.nuts3.yaml
+++ b/ds/data/processed/hebci/spinoff_revenue.nuts3.yaml
@@ -1,27 +1,26 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/
 api_type: FETCH
-data_date: 20200928 
-description_long: Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
-description_short: Total turnover of higher education spin-offs
-description: Total turnover of all spin-off activities associated with higher education institutions.
+data_date: 20200928
+description: Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).
+subtitle: Total turnover of higher education spin-offs
+title: Total turnover of all spin-off activities associated with higher education institutions.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv
 framework_group: knowledge_exchange
 is_experimental: False
-is_public: True 
-order: [year, nuts_id, nuts_year_spec, value.id] 
+is_public: True
+order: [year, nuts_id, nuts_year_spec, value.id]
 region:
   level: 3
   type: NutsRegion
-  source_url: NutsRegion.source_url 
-  source: NutsRegion.source 
+  source_url: NutsRegion.source_url
+  source: NutsRegion.source
 schema:
-  nuts_id: 
-    type: NutsRegion.nuts_id 
-  nuts_year_spec: 
-    type: NutsRegion.nuts_year_spec 
+  nuts_id:
+    type: NutsRegion.nuts_id
+  nuts_year_spec:
+    type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Total turnover of higher education spin-offs
     id: spinoff_revenue
     label: Turnover
     type: GBP
@@ -30,4 +29,3 @@ schema:
     label: Year
 source_name: HESA (Higher Education Statistical Agency)
 source_url: https://www.hesa.ac.uk/
-

--- a/ds/data/processed/hesa/area_university_site.lep.yaml
+++ b/ds/data/processed/hesa/area_university_site.lep.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
 data_date: 20200820
-description_short: Area of university site
-description: Area of university sites for universities in the LEP region
+subtitle: Area of university site
+title: Area of university sites for universities in the LEP region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: LepRegion.year_spec
   value:
     format: .2f
-    description: Site Area (hectares) of university sites
     id: area_university_site
     label: Total area of university sites
     type: Area_hectare

--- a/ds/data/processed/hesa/area_university_site.nuts2.yaml
+++ b/ds/data/processed/hesa/area_university_site.nuts2.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
 data_date: 20200820
-description_short: Area of university site
-description: Area of university sites for universities in the NUTS2 region
+subtitle: Area of university site
+title: Area of university sites for universities in the NUTS2 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -18,7 +18,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     format: .2f
-    description: Site Area (hectares) of university sites
     id: area_university_site
     label: Total area of university sites
     type: Area_hectare

--- a/ds/data/processed/hesa/area_university_site.nuts3.yaml
+++ b/ds/data/processed/hesa/area_university_site.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Area of university site
-description: Area of university sites for universities in the NUTS3 region
+subtitle: Area of university site
+title: Area of university sites for universities in the NUTS3 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     format: .2f
-    description: Site Area (hectares) of university sites
     id: area_university_site
     label: Total area of university sites
     type: Area_hectare

--- a/ds/data/processed/hesa/fte_research_students.lep.yaml
+++ b/ds/data/processed/hesa/fte_research_students.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Number of research students (FTE)
-description: Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the LEP region
+subtitle: Number of research students (FTE)
+title: Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the LEP region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -15,7 +15,6 @@ schema:
   lep_year_spec:
     type: LepRegion.year_spec
   value:
-    description: Full Time Equivalent (FTE) research students
     id: fte_research_students
     label: Research students (Full Time Equivalent)
     type: FTE

--- a/ds/data/processed/hesa/fte_research_students.nuts2.yaml
+++ b/ds/data/processed/hesa/fte_research_students.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Number of research students (FTE)
-description: Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the NUTS2 region
+subtitle: Number of research students (FTE)
+title: Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the NUTS2 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Full Time Equivalent (FTE) research students
     id: fte_research_students
     label: Research students (Full Time Equivalent)
     type: FTE

--- a/ds/data/processed/hesa/fte_research_students.nuts3.yaml
+++ b/ds/data/processed/hesa/fte_research_students.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Number of research students (FTE)
-description: Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the NUTS3 region
+subtitle: Number of research students (FTE)
+title: Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the NUTS3 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Full Time Equivalent (FTE) research students
     id: fte_research_students
     label: Research students (Full Time Equivalent)
     type: FTE

--- a/ds/data/processed/hesa/gbp_research_income.lep.yaml
+++ b/ds/data/processed/hesa/gbp_research_income.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Research income (GBP)
-description: Research income received by universities in the LEP region
+subtitle: Research income (GBP)
+title: Research income received by universities in the LEP region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
     type: LepRegion.year_spec
   value:
     data_type: int
-    description: Research income for universities in the region
     format: ','
     id: gbp_research_income
     label: Research income

--- a/ds/data/processed/hesa/gbp_research_income.nuts2.yaml
+++ b/ds/data/processed/hesa/gbp_research_income.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Research income (GBP)
-description: Research income received by universities in the NUTS2 region
+subtitle: Research income (GBP)
+title: Research income received by universities in the NUTS2 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -18,7 +18,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Research income for universities in the region
     format: ','
     id: gbp_research_income
     label: Research income

--- a/ds/data/processed/hesa/gbp_research_income.nuts3.yaml
+++ b/ds/data/processed/hesa/gbp_research_income.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Research income (GBP)
-description: Research income received by universities in the NUTS3 region
+subtitle: Research income (GBP)
+title: Research income received by universities in the NUTS3 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Research income for universities in the region
     format: ','
     id: gbp_research_income
     label: Research income

--- a/ds/data/processed/hesa/total_postgraduates.lep.yaml
+++ b/ds/data/processed/hesa/total_postgraduates.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of postgraduates
-description: Number of postgraduate (research) students enrolled full-time in universities in a LEP region in the starting academic year.
+subtitle: Total number of postgraduates
+title: Number of postgraduate (research) students enrolled full-time in universities in a LEP region in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
     type: LepRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time students enrolled for postgraduate qualifications in universities in the area
     id: total_postgraduates
     label: Total number of postgraduate students
   year:

--- a/ds/data/processed/hesa/total_postgraduates.nuts2.yaml
+++ b/ds/data/processed/hesa/total_postgraduates.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of postgraduates
-description: Number of postgraduate (research) students enrolled full-time in universities in a NUTS2 region in the starting academic year.
+subtitle: Total number of postgraduates
+title: Number of postgraduate (research) students enrolled full-time in universities in a NUTS2 region in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time students enrolled for postgraduate qualifications in universities in the area
     id: total_postgraduates
     label: Total number of postgraduate students
   year:

--- a/ds/data/processed/hesa/total_postgraduates.nuts3.yaml
+++ b/ds/data/processed/hesa/total_postgraduates.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of postgraduates
-description: Number of postgraduate (research) students enrolled full-time in universities in a NUTS3 region in the starting academic year.
+subtitle: Total number of postgraduates
+title: Number of postgraduate (research) students enrolled full-time in universities in a NUTS3 region in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time students enrolled for postgraduate qualifications in universities in the area
     id: total_postgraduates
     label: Total number of postgraduate students
   year:

--- a/ds/data/processed/hesa/total_stem_postgraduates.lep.yaml
+++ b/ds/data/processed/hesa/total_stem_postgraduates.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of STEM postgraduates
-description: Number of postgraduate (research) students enrolled full-time in STEM subjects in a LEP region (definition of STEM subjects in aux folder) in the starting academic year.
+subtitle: Total number of STEM postgraduates
+title: Number of postgraduate (research) students enrolled full-time in STEM subjects in a LEP region (definition of STEM subjects in aux folder) in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
     type: LepRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time postgraduate students enrolled in STEM subjects in the area (definition of STEM subjects in aux folder)
     id: total_stem_postgraduates
     label: Total number of postgraduate students in STEM subjects
   year:

--- a/ds/data/processed/hesa/total_stem_postgraduates.nuts2.yaml
+++ b/ds/data/processed/hesa/total_stem_postgraduates.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of STEM postgraduates
-description: Number of postgraduate (research) students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.
+subtitle: Total number of STEM postgraduates
+title: Number of postgraduate (research) students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time postgraduate students enrolled in STEM subjects in the area (definition of STEM subjects in aux folder)
     id: total_stem_postgraduates
     label: Total number of postgraduate students in STEM subjects
   year:

--- a/ds/data/processed/hesa/total_stem_postgraduates.nuts3.yaml
+++ b/ds/data/processed/hesa/total_stem_postgraduates.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of STEM postgraduates
-description: Number of postgraduate (research) students enrolled full-time in STEM subjects in a NUTS3 region (definition of STEM subjects in aux folder) in the starting academic year.
+subtitle: Total number of STEM postgraduates
+title: Number of postgraduate (research) students enrolled full-time in STEM subjects in a NUTS3 region (definition of STEM subjects in aux folder) in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time postgraduate students enrolled in STEM subjects in the area (definition of STEM subjects in aux folder)
     id: total_stem_postgraduates
     label: Total number of postgraduate students in STEM subjects
   year:

--- a/ds/data/processed/hesa/total_stem_students.lep.yaml
+++ b/ds/data/processed/hesa/total_stem_students.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of STEM students
-description: Number of students enrolled full-time in STEM subjects in a LEP region (definition of STEM subjects in aux folder) in the starting academic year.
+subtitle: Total number of STEM students
+title: Number of students enrolled full-time in STEM subjects in a LEP region (definition of STEM subjects in aux folder) in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
     type: LepRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time students enrolled in STEM subjects in the area
     id: total_stem_students
     label: Total number of students in STEM subjects
   year:

--- a/ds/data/processed/hesa/total_stem_students.nuts2.yaml
+++ b/ds/data/processed/hesa/total_stem_students.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of STEM students
-description: Number of students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.
+subtitle: Total number of STEM students
+title: Number of students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time students enrolled in STEM subjects in the area
     id: total_stem_students
     label: Total number of students in STEM subjects
   year:

--- a/ds/data/processed/hesa/total_stem_students.nuts3.yaml
+++ b/ds/data/processed/hesa/total_stem_students.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/students
 api_type: FETCH
-description_short: Total number of STEM students
-description: Number of students enrolled full-time in STEM subjects in a NUTS3 region (definition of STEM subjects in aux folder) in the starting academic year.
+subtitle: Total number of STEM students
+title: Number of students enrolled full-time in STEM subjects in a NUTS3 region (definition of STEM subjects in aux folder) in the starting academic year.
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of full-time students enrolled in STEM subjects in the area
     id: total_stem_students
     label: Total number of students in STEM subjects
   year:

--- a/ds/data/processed/hesa/total_university_buildings.lep.yaml
+++ b/ds/data/processed/hesa/total_university_buildings.lep.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Total number of university buildings
-description: Number of university buildings in a LEP region
+subtitle: Total number of university buildings
+title: Number of university buildings in a LEP region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -16,7 +16,6 @@ schema:
     type: LepRegion.year_spec
   value:
     data_type: int
-    description: Total number of buildings in the area
     id: total_university_buildings
     label: Total number of buildings
   year:

--- a/ds/data/processed/hesa/total_university_buildings.nuts2.yaml
+++ b/ds/data/processed/hesa/total_university_buildings.nuts2.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Total number of university buildings
-description: Number of university buildings in a NUTS2 region
+subtitle: Total number of university buildings
+title: Number of university buildings in a NUTS2 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of buildings in the area
     id: total_university_buildings
     label: Total number of buildings
   year:

--- a/ds/data/processed/hesa/total_university_buildings.nuts3.yaml
+++ b/ds/data/processed/hesa/total_university_buildings.nuts3.yaml
@@ -1,7 +1,7 @@
 api_doc_url: https://www.hesa.ac.uk/data-and-analysis/estates/table-1
 api_type: FETCH
-description_short: Total number of university buildings
-description: Number of university buildings in a NUTS3 region
+subtitle: Total number of university buildings
+title: Number of university buildings in a NUTS3 region
 endpoint_url: https://www.hesa.ac.uk/data-and-analysis/estates/data.csv
 framework_group: public_rnd_capability
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
     type: NutsRegion.year_spec
   value:
     data_type: int
-    description: Total number of buildings in the area
     id: total_university_buildings
     label: Total number of buildings
   year:

--- a/ds/data/processed/housing/house_price_normalised.nuts2.yaml
+++ b/ds/data/processed/housing/house_price_normalised.nuts2.yaml
@@ -7,9 +7,9 @@ api_type:
   Business Register Employment Survey (BRES): POST
   House price index (HPI): FETCH
 data_date: 20201808
-description_long: This indicator captures housing costs in a location. It takes the mean price of a house in a location and normalises it by the mean salary of its residents. Higher values represent lower house affordability for residents
-description_short: Housing prices normalised by resident salaries
-description: Salary and Housing price data is available at the Local Authority District levels so we had to convert mean salaries (house prices) into volumes taking into account the number of people employed (transactions undertaken) in a location and aggregate at the NUTS level through a lookup table.
+description: This indicator captures housing costs in a location. It takes the mean price of a house in a location and normalises it by the mean salary of its residents. Higher values represent lower house affordability for residents
+subtitle: Housing prices normalised by resident salaries
+title: Salary and Housing price data is available at the Local Authority District levels so we had to convert mean salaries (house prices) into volumes taking into account the number of people employed (transactions undertaken) in a location and aggregate at the NUTS level through a lookup table.
 endpoint_url:
   Annual Survey of Hours and Earnings resident data (ASHE): https://www.nomisweb.co.uk/api/v01/dataset/NM_30_1.data.csv
   Business Register Employment Survey (BRES): https://www.nomisweb.co.uk/api/v01/dataset/NM_189_1.data.csv
@@ -29,7 +29,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: float
-    description: Mean housing prices normalised by mean salaries of full time
     format: .3f
     id: house_price_normalised
     label: Housing prices normalised by regional salaries

--- a/ds/data/processed/housing/house_price_normalised.nuts3.yaml
+++ b/ds/data/processed/housing/house_price_normalised.nuts3.yaml
@@ -7,9 +7,9 @@ api_type:
   Business Register Employment Survey (BRES): POST
   House price index (HPI): FETCH
 data_date: 20201808
-description_long: This indicator captures housing costs in a location. It takes the mean price of a house in a location and normalises it by the mean salary of its residents. Higher values represent lower house affordability for residents
-description_short: Housing prices normalised by resident salaries
-description: Salary and Housing price data is available at the Local Authority District levels so we had to convert mean salaries (house prices) into volumes taking into account the number of people employed (transactions undertaken) in a location and aggregate at the NUTS level through a lookup table.
+description: This indicator captures housing costs in a location. It takes the mean price of a house in a location and normalises it by the mean salary of its residents. Higher values represent lower house affordability for residents
+subtitle: Housing prices normalised by resident salaries
+title: Salary and Housing price data is available at the Local Authority District levels so we had to convert mean salaries (house prices) into volumes taking into account the number of people employed (transactions undertaken) in a location and aggregate at the NUTS level through a lookup table.
 endpoint_url:
   Annual Survey of Hours and Earnings resident data (ASHE): https://www.nomisweb.co.uk/api/v01/dataset/NM_30_1.data.csv
   Business Register Employment Survey (BRES): https://www.nomisweb.co.uk/api/v01/dataset/NM_189_1.data.csv
@@ -29,7 +29,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: float
-    description: Mean housing prices normalised by mean salaries of full time
     format: .3f
     id: house_price_normalised
     label: Housing prices normalised by regional salaries

--- a/ds/data/processed/industry/economic_complexity_index.yaml
+++ b/ds/data/processed/industry/economic_complexity_index.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: POST
 data_date: 20200218
-description_short: Economic Complexity Index
-description: This indicator measures the economic complexity of a location based on an analysis of its industrial composition ((based on Nesta sectoral definition, which clusters 4-digit SIC codes based on their similarity))
+subtitle: Economic Complexity Index
+title: This indicator measures the economic complexity of a location based on an analysis of its industrial composition ((based on Nesta sectoral definition, which clusters 4-digit SIC codes based on their similarity))
 endpoint_url: http://www.nomisweb.co.uk/api/v01/dataset/
 framework_group: business_rnd_capacity
 is_experimental: True
@@ -17,7 +17,6 @@ schema:
   region_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Economic complexity Index
     format: .4f
     id: economic_complexity_index
     label: Economic complexity Index

--- a/ds/data/processed/industry/employment_culture_entertainment_recreation.yaml
+++ b/ds/data/processed/industry/employment_culture_entertainment_recreation.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.nomisweb.co.uk/api/v01/help
 api_type: POST
 data_date: 20200218
-description_short: Employment in cultural, entertainment and leisure industries
-description: This indicator measures level of employment in cultural, entertainment and leisure industries based on the Business Register Employment Survey. Those sectors are identified as clusters of SIC-4 (industry) codes
+subtitle: Employment in cultural, entertainment and leisure industries
+title: This indicator measures level of employment in cultural, entertainment and leisure industries based on the Business Register Employment Survey. Those sectors are identified as clusters of SIC-4 (industry) codes
 endpoint_url: http://www.nomisweb.co.uk/api/v01/dataset/
 framework_group: place_potential
 is_experimental: True
@@ -17,7 +17,6 @@ schema:
   region_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Total employment in cultural, entertainment and leisure industries
     id: employment_culture_entertainment_recreation
     label: Employment in cultural, entertainment and leisure industries
     data_type: int

--- a/ds/data/processed/innovate_uk/gbp_innovate_uk_funding.nuts2.yaml
+++ b/ds/data/processed/innovate_uk/gbp_innovate_uk_funding.nuts2.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://www.gov.uk/government/publications/innovate-uk-funded-projects
 api_type: FETCH
 data_date: 20200821
-description_long: Level of funding awarded by Innovate UK to organisations in a region. Only includes awards that have not been withdrawn are not on hold.
-description_short: Funding received from Innovate UK
-description: This indicator aggregates all funding awarded by Innovate UK to organisations in a location according to the open IUK transparency dataset. It was not possible to match a small fraction of the awards due to issues with the postcodes.
+description: Level of funding awarded by Innovate UK to organisations in a region. Only includes awards that have not been withdrawn are not on hold.
+subtitle: Funding received from Innovate UK
+title: This indicator aggregates all funding awarded by Innovate UK to organisations in a location according to the open IUK transparency dataset. It was not possible to match a small fraction of the awards due to issues with the postcodes.
 endpoint_url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/909140/20200801_Innovate_UK_Funded_Projects.xlsx
 framework_group: public_rnd_capability
 is_experimental: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Funding received from innovate UK
     format: ','
     id: gbp_innovate_uk_funding
     label: Funding received from Innovate UK

--- a/ds/data/processed/innovate_uk/gbp_innovate_uk_funding.nuts3.yaml
+++ b/ds/data/processed/innovate_uk/gbp_innovate_uk_funding.nuts3.yaml
@@ -1,9 +1,9 @@
 api_doc_url: https://www.gov.uk/government/publications/innovate-uk-funded-projects
 api_type: FETCH
 data_date: 20200821
-description_long: Level of funding awarded by Innovate UK to organisations in a region. Only includes awards that have not been withdrawn are not on hold.
-description_short: Funding received from Innovate UK
-description: This indicator aggregates all funding awarded by Innovate UK to organisations in a location according to the open IUK transparency dataset. It was not possible to match a small fraction of the awards due to issues with the postcodes.
+description: Level of funding awarded by Innovate UK to organisations in a region. Only includes awards that have not been withdrawn are not on hold.
+subtitle: Funding received from Innovate UK
+title: This indicator aggregates all funding awarded by Innovate UK to organisations in a location according to the open IUK transparency dataset. It was not possible to match a small fraction of the awards due to issues with the postcodes.
 endpoint_url: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/909140/20200801_Innovate_UK_Funded_Projects.xlsx
 framework_group: public_rnd_capability
 is_experimental: False
@@ -19,7 +19,6 @@ schema:
     type: NutsRegion.nuts_year_spec
   value:
     data_type: int
-    description: Funding received from innovate UK
     format: ','
     id: gbp_innovate_uk_funding
     label: Funding received from Innovate UK

--- a/ds/data/processed/patents/total_inventions.yaml
+++ b/ds/data/processed/patents/total_inventions.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://github.com/nestauk/patent_analysis/raw/master/references/patstat_data_dict.pdf
 api_type: MySQL
 data_date: 20202002
-description_short: Total unique inventions
-description: Total number of unique inventions involving organisations in the NUTS2 region in a year (we consider the earliest application year for all patents in the family)
+subtitle: Total unique inventions
+title: Total number of unique inventions involving organisations in the NUTS2 region in a year (we consider the earliest application year for all patents in the family)
 endpoint_url: https://github.com/nestauk/imt_playbook/blob/dev/daps/sql.md
 framework_group: knowledge_exchange
 is_experimental: True
@@ -17,7 +17,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Total number of unique inventions involving organisations in the NUTS2 region in a year (we consider the earliest application year for all patents in the family)
     id: total_inventions
     label: Total unique inventions
     data_type: int

--- a/ds/data/processed/ref/mean_ref.yaml
+++ b/ds/data/processed/ref/mean_ref.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.ref.ac.uk/2014/pubs/201401/
 api_type: FETCH
 data_date: 20200204
-description_short: Mean REF score
-description: These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year
+subtitle: Mean REF score
+title: These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year
 endpoint_url: https://results.ref.ac.uk/(S(hlvnuqzwkag44jp3df3d4q14))/DownloadFile/AllResults/xlsx
 framework_group: public_rnd_capability
 is_experimental: False
@@ -18,7 +18,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.year_spec
   value:
-    description: The mean REF score for the NUTS2 area. This is the average of the scores in all departments weighted by the Full time equivalents submitted in each category (4*, 3*, 2* with higher scores representing better assessments)
     format: .2f
     id: mean_ref
     label: Mean Research Excellence Framework Score

--- a/ds/data/processed/ref/mean_ref_stem.yaml
+++ b/ds/data/processed/ref/mean_ref_stem.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.ref.ac.uk/2014/pubs/201401/
 api_type: FETCH
 data_date: 20200204
-description_short: Mean REF Score in STEM disciplines
-description: These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year
+subtitle: Mean REF Score in STEM disciplines
+title: These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year
 endpoint_url: https://results.ref.ac.uk/(S(hlvnuqzwkag44jp3df3d4q14))/DownloadFile/AllResults/xlsx
 framework_group: public_rnd_capability
 is_experimental: False
@@ -18,7 +18,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.year_spec
   value:
-    description: The mean REF score for the NUTS2 area considering only STEM subjects (see aux/ref_stem.txt) for the subjects that we selected. This is the average of the scores in all departments weighted by the Full time equivalents submitted in each category (4*, 3*, 2* with higher scores representing better assessments)
     format: .2f
     id: mean_ref_stem
     label: Mean Research Excellence Framework Score

--- a/ds/data/processed/ref/total_4_fte.yaml
+++ b/ds/data/processed/ref/total_4_fte.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.ref.ac.uk/2014/pubs/201401/
 api_type: FETCH
 data_date: 20200204
-description_short: Total number of researchers assessed as excellent
-description: These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year
+subtitle: Total number of researchers assessed as excellent
+title: These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year
 endpoint_url: https://results.ref.ac.uk/(S(hlvnuqzwkag44jp3df3d4q14))/DownloadFile/AllResults/xlsx
 framework_group: public_rnd_capability
 is_experimental: False
@@ -18,7 +18,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.year_spec
   value:
-    description: The total number of excellent researchers (4* score) submitted by universities in the NUTS-2 region for the 2014 REF
     format: .2f
     id: total_4_fte
     label: Total number of excellent researchers in REF (Full Time Equivalent)

--- a/ds/data/processed/trademarks/total_trademarks.yaml
+++ b/ds/data/processed/trademarks/total_trademarks.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.gov.uk/government/publications/ipo-trade-mark-data-release/ipo-data-explained-2016
 api_type: FETCH
 data_date: 20200225
-description_short: Total number of trademarks
-description: Total number of trademarks published by organisations in the region based on the IPO open trademark dataset
+subtitle: Total number of trademarks
+title: Total number of trademarks published by organisations in the region based on the IPO open trademark dataset
 endpoint_url: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/680986/opendatadomestic.zip
 framework_group: knowledge_exchange
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Total number of trademarks published by organisations in the region based on the IPO open trademark dataset
     id: total_trademarks
     label: Total trademarks
     data_type: int

--- a/ds/data/processed/trademarks/total_trademarks_scientific.yaml
+++ b/ds/data/processed/trademarks/total_trademarks_scientific.yaml
@@ -1,8 +1,8 @@
 api_doc_url: https://www.gov.uk/government/publications/ipo-trade-mark-data-release/ipo-data-explained-2016
 api_type: FETCH
 data_date: 20200225
-description_short: Total number of trademarks in science and technology fields
-description: Total number of trademarks in scientific and technological product fields published by organisations in the region based on the IPO open trademark dataset
+subtitle: Total number of trademarks in science and technology fields
+title: Total number of trademarks in scientific and technological product fields published by organisations in the region based on the IPO open trademark dataset
 endpoint_url: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/680986/opendatadomestic.zip
 framework_group: knowledge_exchange
 is_experimental: False
@@ -17,7 +17,6 @@ schema:
   nuts_year_spec:
     type: NutsRegion.nuts_year_spec
   value:
-    description: Total number of trademarks in scientific and technological product fields published by organisations in the region based on the IPO open trademark dataset
     id: total_trademarks_scientific
     label: Total number of trademarks in science and technology fields
     data_type: int

--- a/ds/data/schema/schema_template.yaml
+++ b/ds/data/schema/schema_template.yaml
@@ -14,13 +14,11 @@ api_type: string|string[]|{key, string}
     # MySQL: the data is obtained by querying a MySQL endpoint
 auth_provider: string|URL # OPTIONAL – in case the source is not public, the name of the organization providing source access or a URL of a web page where to get or require access, e.g. Nesta, or https://www.foo.com/get_auth
 data_date: Date_YYYYMMDD # OPTIONAL - the date of the data processing, e.g. 20201213
-description_long: string # a long description of the indicator: this is useful for a non-expert audience to have some short explanations about the data limitations (E.g. on Higher Edu R&D, they might wonder why we only have data for parts of the country), and foibles (e.g. on area of university site they may wonder about the Inner London West spike of 2016)
-description_short: string # a brief description of the indicator short enough to be used in menus or sidebars (~40 chars)
-description: string # a description of the indicator, of the data source and transformations that have been applied
+description: string # a long description of the indicator: this is useful for a non-expert audience to have some short explanations about the data limitations (E.g. on Higher Edu R&D, they might wonder why we only have data for parts of the country), and foibles (e.g. on area of university site they may wonder about the Inner London West spike of 2016)
+derived_from: string[] # OPTIONAL - list of indicator keys this indicator derives from
 endpoint_url: URL|URL[]|{key, URL} # use an array of URLs or an object if multiple files have been downloaded to build this indicator (key can be a year or a free identifier)
   # for querying APIs: the URL of the api endpoint at which queries can be executed
   # for fetching: the URL where to fetch the data
-derived_from: string[] # OPTIONAL - list of indicator keys this indicator derives from
 framework_group: string # key for the framework group that contains this indicator (from data/aux/framework.json)
 is_experimental: boolean # whether this indicator is experimental
 is_public: boolean # OPTIONAL – provide this if False in case the source is not public
@@ -37,8 +35,9 @@ schema:
   <region_type>_year_spec: # change this key to `nuts_year_spec` or `lep_year_spec`
     type: GeoRegion.<region_type>_year_spec # change this key to `NutsRegion.nuts_year_spec` or `LepRegion.lep_year_spec`
   value:
-    data_type: string # (XOR `type`) - use for native types like counts (int) or simple mean values (float). Consider using `type` if the unit has a well known Type (e.g. EUR, densities, etc.)
-    description: string # a description of the value
+    data_type: string
+      # OPTIONAL - (XOR `type`) use for native types like counts (int) or simple mean values (float). Consider using `type` if the unit has a well known Type (e.g. EUR, densities, etc.)
+      # for currencies, please use `data_type: int`, this helps limiting the decimal part in the bar chart label for the average value
     format: string # OPTIONAL - the render format, useful for floats or dates (e.g. `.2f`), see [1] and [2], not needed for integers
     id: string # indicator name, should be identical to the file name (e.g. `berd` and `berd.csv`)
     label: string # a short text to be used as a label in charts
@@ -53,6 +52,8 @@ source_name: string|string[]|{key, string}
 source_url: URL|URL[]|{key, URL}
   # the URL of the data provider (e.g. https://gtr.ukri.org)
   # use an array of URLs or an object if multiple files have been downloaded to build this indicator (key can be a year or a free identifier)
+subtitle: string # a brief description of the indicator short enough to be used in menus or sidebars (~40 chars)
+title: string # a description of the indicator, of the data source and transformations that have been applied
 warning: string # OPTIONAL - a note the user to be shown in the indicator info panel
 
 

--- a/ui/src/bin/copy_data.js
+++ b/ui/src/bin/copy_data.js
@@ -90,8 +90,8 @@ const run = async () => {
 						types[spec.schema.value.type].unit_string,
 					_.always('')
 				]),
-				description_short: () => spec.description_short,
-				description: () => spec.description,
+				subtitle: () => spec.subtitle,
+				title: () => spec.title,
 			})))
 		)
 	)

--- a/ui/src/node_modules/app/components/InfoModal/InfoModal.svelte
+++ b/ui/src/node_modules/app/components/InfoModal/InfoModal.svelte
@@ -18,7 +18,7 @@
 	export let api_type;
 	export let auth_provider;
 	export let data_date;
-	export let description_long;
+	export let description;
 	export let endpoint_url;
 	export let is_experimental;
 	export let is_public;
@@ -41,8 +41,8 @@
 	>
 		<h2>About the data</h2>
 
-		{#if description_long}
-			<p class='longDesc'>{description_long}</p>
+		{#if description}
+			<p class='longDesc'>{description}</p>
 		{/if}
 
 		{#if date}

--- a/ui/src/node_modules/app/data/indicatorsGroups.json
+++ b/ui/src/node_modules/app/data/indicatorsGroups.json
@@ -8,8 +8,8 @@
       {
         "api_doc_url": "https://www.nomisweb.co.uk/api/v01/help",
         "api_type": "FETCH",
-        "description_short": "Associated STEM professionals",
-        "description": "Number of Science, Research, Engineering and Technology associated professionals by NUTS 2 regions.",
+        "subtitle": "Associated STEM professionals",
+        "title": "Number of Science, Research, Engineering and Technology associated professionals by NUTS 2 regions.",
         "endpoint_url": {
           "2010": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&cell=404882177,404883201&measures=20100,20701,",
           "2013": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&cell=404882177,404883201&measures=20100,20701,",
@@ -36,7 +36,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Number of Science, Research, Engineering and Technology associated professionals.",
             "id": "aps_econ_active_stem_associate_profs_data",
             "label": "Frequency",
             "data_type": "int"
@@ -57,8 +56,8 @@
       {
         "api_doc_url": "https://www.nomisweb.co.uk/api/v01/help",
         "api_type": "FETCH",
-        "description_short": "STEM professionals",
-        "description": "Number of Science, Research, Engineering and Technology professionals by NUTS 2 regions.",
+        "subtitle": "STEM professionals",
+        "title": "Number of Science, Research, Engineering and Technology professionals by NUTS 2 regions.",
         "endpoint_url": {
           "2010": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&cell=404882177,404883201&measures=20100,20701,",
           "2013": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_1.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&cell=404882177,404883201&measures=20100,20701,",
@@ -85,7 +84,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Number of Science, Research, Engineering and Technology professionals.",
             "id": "aps_econ_active_stem_profs_data",
             "label": "Frequency",
             "data_type": "int"
@@ -106,8 +104,8 @@
       {
         "api_doc_url": "https://www.nomisweb.co.uk/api/v01/help",
         "api_type": "FETCH",
-        "description_short": "Economically active in professionals",
-        "description": "Percentage of economically active persons in professional occupations by NUTS 2 regions.",
+        "subtitle": "Economically active in professionals",
+        "title": "Percentage of economically active persons in professional occupations by NUTS 2 regions.",
         "endpoint_url": {
           "2010": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=353&measures=20599,21001,21002,21003,",
           "2013": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=353&measures=20599,21001,21002,21003,",
@@ -135,7 +133,6 @@
           },
           "value": {
             "data_type": "float",
-            "description": "Percentage of population employed in professional occupations.",
             "format": ".1f",
             "id": "aps_nvq4_education_data",
             "label": "Percentage",
@@ -157,8 +154,8 @@
       {
         "api_doc_url": "https://www.nomisweb.co.uk/api/v01/help",
         "api_type": "FETCH",
-        "description_short": "Professional occupations employment",
-        "description": "Percentage of population employed in professional occupations by NUTS 2 regions.",
+        "subtitle": "Professional occupations employment",
+        "title": "Percentage of population employed in professional occupations by NUTS 2 regions.",
         "endpoint_url": {
           "2010": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=1533&measures=20599,21001,21002,21003,",
           "2013": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=1533&measures=20599,21001,21002,21003,",
@@ -186,7 +183,6 @@
           },
           "value": {
             "data_type": "float",
-            "description": "Percentage of population employed in professional occupations.",
             "format": ".1f",
             "id": "aps_pro_occupations_data",
             "label": "Percentage",
@@ -209,9 +205,9 @@
         "api_doc_url": "https://data.europa.eu/euodp/en/data/dataset/cordisH2020projects",
         "api_type": "FETCH",
         "data_date": 20200909,
-        "description_long": "Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.",
-        "description_short": "Horizon 2020 funding",
-        "description": "Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.",
+        "description": "Total amount of funding (in Euros) awarded by the European Commission for research, development and innovation projects carried out during the Horizon 2020 funding programme (2014 - 2020). Organisations that recieve such funding include (but are not limited to) higher education establishments, private companies, public institutions and research centres. The funding is grouped by the start year of the project.",
+        "subtitle": "Horizon 2020 funding",
+        "title": "Sum of all European Commission funding awarded to organisations as part of Horizon 2020 projects. Years prior to 2014 and after 2020 have been excluded.",
         "endpoint_url": {
           "H2020 projects": "https://cordis.europa.eu/data/cordis-h2020projects-xml.zip",
           "H2020 project descriptions": "https://cordis.europa.eu/data/cordis-h2020projects.csv"
@@ -238,7 +234,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "total Horizon 2020 funding",
             "format": ",",
             "id": "cordis_funding",
             "label": "Total Funding",
@@ -260,8 +255,8 @@
       {
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm",
         "api_type": "FETCH",
-        "description_short": "Government R&D",
-        "description": "Government performed research & development (R&D) expenditure by NUTS 2 regions.",
+        "subtitle": "Government R&D",
+        "title": "Government performed research & development (R&D) expenditure by NUTS 2 regions.",
         "endpoint_url": "http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=2&sectperf=GOV&unit=MIO_EUR",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -285,7 +280,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "government performed R&D expenditure in euros (to the nearest 1000)",
             "format": ",",
             "id": "eurostat_gov_rd_workforce_data",
             "label": "Expenditure (to nearest 1000)",
@@ -307,8 +301,8 @@
       {
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm",
         "api_type": "FETCH",
-        "description_short": "Higher Edu R&D",
-        "description": "Higher education sector enterprise research & development (R&D) expenditure by NUTS 2 regions.",
+        "subtitle": "Higher Edu R&D",
+        "title": "Higher education sector enterprise research & development (R&D) expenditure by NUTS 2 regions.",
         "endpoint_url": "http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=6&sectperf=HES&unit=MIO_EUR'",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -332,7 +326,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Higher education sector R&D expenditure in euros (to the nearest 1000)",
             "format": ",",
             "id": "eurostat_higher_ed_rd_workforce_data",
             "label": "Expenditure (to nearest 1000)",
@@ -354,8 +347,8 @@
       {
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm",
         "api_type": "FETCH",
-        "description_short": "Private non-profit R&D",
-        "description": "Private non-profit sector enterprise research & development (R&D) expenditure by NUTS 2 regions.",
+        "subtitle": "Private non-profit R&D",
+        "title": "Private non-profit sector enterprise research & development (R&D) expenditure by NUTS 2 regions.",
         "endpoint_url": "http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=6&sectperf=PNP&unit=MIO_EUR'",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -379,7 +372,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Private non-profit sector R&D expenditure in euros (to the nearest 1000)",
             "format": ",",
             "id": "eurostat_private_non_profit_rd_workforce_data",
             "label": "Expenditure (to nearest 1000)",
@@ -403,8 +395,8 @@
         "api_type": "FETCH",
         "auth_provider": "Nesta",
         "data_date": 20200222,
-        "description_short": "STEM projects led by organisations in the region",
-        "description": "Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)",
+        "subtitle": "STEM projects led by organisations in the region",
+        "title": "Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)",
         "endpoint_url": "https://s3.console.aws.amazon.com/s3/object/nesta-data-getters/17_9_2019_gtr_orgs.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": true,
@@ -429,7 +421,6 @@
             "type": "NutsRegion.year_spec"
           },
           "value": {
-            "description": "Total number of projects led by organisations in the NUTS area in STEM subjects (see aux/gtr_stem_disciplines for the stem disciplines we are considering)",
             "format": ",",
             "id": "total_gtr_projects_stem",
             "label": "Number of projects in STEM disciplines led by organisations in the region",
@@ -453,9 +444,9 @@
         "api_type": "MySQL",
         "auth_provider": "Nesta",
         "data_date": 20200910,
-        "description_long": "Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.",
-        "description_short": "Total funding (GBP) for research awarded by UKRI",
-        "description": "Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)",
+        "description": "Total amount of funding (GBP) awarded by UK Research and Innovation (UKRI) for research and innovation projects. Organisations that recieve funding include universities and private companies. Some projects have multiple organisations who may have been awarded funding, however due to limitations with the data provided by Gateway to Research we have attributed the total funding for a project to the lead organisation.",
+        "subtitle": "Total funding (GBP) for research awarded by UKRI",
+        "title": "Sum of all research funding (GBP) awarded by UK Research and Innovation (UKRI)",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
         "is_public": false,
@@ -478,7 +469,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total funding (GBP) for research awarded by UKRI",
             "format": ",",
             "id": "total_ukri_funding",
             "label": "Total Funding",
@@ -501,8 +491,8 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/estates/table-1",
         "api_type": "FETCH",
         "data_date": 20200820,
-        "description_short": "Area of university site",
-        "description": "Area of university sites for universities in the NUTS2 region",
+        "subtitle": "Area of university site",
+        "title": "Area of university sites for universities in the NUTS2 region",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/estates/data.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -526,7 +516,6 @@
           },
           "value": {
             "format": ".2f",
-            "description": "Site Area (hectares) of university sites",
             "id": "area_university_site",
             "label": "Total area of university sites",
             "type": "Area_hectare"
@@ -547,8 +536,8 @@
       {
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/estates/table-1",
         "api_type": "FETCH",
-        "description_short": "Number of research students (FTE)",
-        "description": "Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the NUTS2 region",
+        "subtitle": "Number of research students (FTE)",
+        "title": "Aggregate of Full Time Equivalent (FTE) of research students enrolled in universities in the NUTS2 region",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/estates/data.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -572,7 +561,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Full Time Equivalent (FTE) research students",
             "id": "fte_research_students",
             "label": "Research students (Full Time Equivalent)",
             "type": "FTE"
@@ -593,8 +581,8 @@
       {
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/estates/table-1",
         "api_type": "FETCH",
-        "description_short": "Research income (GBP)",
-        "description": "Research income received by universities in the NUTS2 region",
+        "subtitle": "Research income (GBP)",
+        "title": "Research income received by universities in the NUTS2 region",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/estates/data.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -619,7 +607,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Research income for universities in the region",
             "format": ",",
             "id": "gbp_research_income",
             "label": "Research income",
@@ -641,8 +628,8 @@
       {
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/students",
         "api_type": "FETCH",
-        "description_short": "Total number of postgraduates",
-        "description": "Number of postgraduate (research) students enrolled full-time in universities in a NUTS2 region in the starting academic year.",
+        "subtitle": "Total number of postgraduates",
+        "title": "Number of postgraduate (research) students enrolled full-time in universities in a NUTS2 region in the starting academic year.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -666,7 +653,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total number of full-time students enrolled for postgraduate qualifications in universities in the area",
             "id": "total_postgraduates",
             "label": "Total number of postgraduate students"
           },
@@ -686,8 +672,8 @@
       {
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/students",
         "api_type": "FETCH",
-        "description_short": "Total number of STEM postgraduates",
-        "description": "Number of postgraduate (research) students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.",
+        "subtitle": "Total number of STEM postgraduates",
+        "title": "Number of postgraduate (research) students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -711,7 +697,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total number of full-time postgraduate students enrolled in STEM subjects in the area (definition of STEM subjects in aux folder)",
             "id": "total_stem_postgraduates",
             "label": "Total number of postgraduate students in STEM subjects"
           },
@@ -731,8 +716,8 @@
       {
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/students",
         "api_type": "FETCH",
-        "description_short": "Total number of STEM students",
-        "description": "Number of students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.",
+        "subtitle": "Total number of STEM students",
+        "title": "Number of students enrolled full-time in STEM subjects in a NUTS2 region (definition of STEM subjects in aux folder) in the starting academic year.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/students/table-13.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -756,7 +741,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total number of full-time students enrolled in STEM subjects in the area",
             "id": "total_stem_students",
             "label": "Total number of students in STEM subjects"
           },
@@ -776,8 +760,8 @@
       {
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/estates/table-1",
         "api_type": "FETCH",
-        "description_short": "Total number of university buildings",
-        "description": "Number of university buildings in a NUTS2 region",
+        "subtitle": "Total number of university buildings",
+        "title": "Number of university buildings in a NUTS2 region",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/estates/data.csv",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -801,7 +785,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total number of buildings in the area",
             "id": "total_university_buildings",
             "label": "Total number of buildings"
           },
@@ -822,9 +805,9 @@
         "api_doc_url": "https://www.gov.uk/government/publications/innovate-uk-funded-projects",
         "api_type": "FETCH",
         "data_date": 20200821,
-        "description_long": "Level of funding awarded by Innovate UK to organisations in a region. Only includes awards that have not been withdrawn are not on hold.",
-        "description_short": "Funding received from Innovate UK",
-        "description": "This indicator aggregates all funding awarded by Innovate UK to organisations in a location according to the open IUK transparency dataset. It was not possible to match a small fraction of the awards due to issues with the postcodes.",
+        "description": "Level of funding awarded by Innovate UK to organisations in a region. Only includes awards that have not been withdrawn are not on hold.",
+        "subtitle": "Funding received from Innovate UK",
+        "title": "This indicator aggregates all funding awarded by Innovate UK to organisations in a location according to the open IUK transparency dataset. It was not possible to match a small fraction of the awards due to issues with the postcodes.",
         "endpoint_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/909140/20200801_Innovate_UK_Funded_Projects.xlsx",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -848,7 +831,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Funding received from innovate UK",
             "format": ",",
             "id": "gbp_innovate_uk_funding",
             "label": "Funding received from Innovate UK",
@@ -871,8 +853,8 @@
         "api_doc_url": "https://www.ref.ac.uk/2014/pubs/201401/",
         "api_type": "FETCH",
         "data_date": 20200204,
-        "description_short": "Mean REF score",
-        "description": "These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year",
+        "subtitle": "Mean REF score",
+        "title": "These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year",
         "endpoint_url": "https://results.ref.ac.uk/(S(hlvnuqzwkag44jp3df3d4q14))/DownloadFile/AllResults/xlsx",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -896,7 +878,6 @@
             "type": "NutsRegion.year_spec"
           },
           "value": {
-            "description": "The mean REF score for the NUTS2 area. This is the average of the scores in all departments weighted by the Full time equivalents submitted in each category (4*, 3*, 2* with higher scores representing better assessments)",
             "format": ".2f",
             "id": "mean_ref",
             "label": "Mean Research Excellence Framework Score",
@@ -919,8 +900,8 @@
         "api_doc_url": "https://www.ref.ac.uk/2014/pubs/201401/",
         "api_type": "FETCH",
         "data_date": 20200204,
-        "description_short": "Mean REF Score in STEM disciplines",
-        "description": "These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year",
+        "subtitle": "Mean REF Score in STEM disciplines",
+        "title": "These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year",
         "endpoint_url": "https://results.ref.ac.uk/(S(hlvnuqzwkag44jp3df3d4q14))/DownloadFile/AllResults/xlsx",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -944,7 +925,6 @@
             "type": "NutsRegion.year_spec"
           },
           "value": {
-            "description": "The mean REF score for the NUTS2 area considering only STEM subjects (see aux/ref_stem.txt) for the subjects that we selected. This is the average of the scores in all departments weighted by the Full time equivalents submitted in each category (4*, 3*, 2* with higher scores representing better assessments)",
             "format": ".2f",
             "id": "mean_ref_stem",
             "label": "Mean Research Excellence Framework Score",
@@ -967,8 +947,8 @@
         "api_doc_url": "https://www.ref.ac.uk/2014/pubs/201401/",
         "api_type": "FETCH",
         "data_date": 20200204,
-        "description_short": "Total number of researchers assessed as excellent",
-        "description": "These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year",
+        "subtitle": "Total number of researchers assessed as excellent",
+        "title": "These are the results of the Research Excellence Framework, where university departments in various disciplines are assessed on the quality of their research. The latest REF was conducted in 2014 so data is available only for one year",
         "endpoint_url": "https://results.ref.ac.uk/(S(hlvnuqzwkag44jp3df3d4q14))/DownloadFile/AllResults/xlsx",
         "framework_group": "public_rnd_capability",
         "is_experimental": false,
@@ -992,7 +972,6 @@
             "type": "NutsRegion.year_spec"
           },
           "value": {
-            "description": "The total number of excellent researchers (4* score) submitted by universities in the NUTS-2 region for the 2014 REF",
             "format": ".2f",
             "id": "total_4_fte",
             "label": "Total number of excellent researchers in REF (Full Time Equivalent)",
@@ -1022,8 +1001,8 @@
       {
         "api_doc_url": "https://www.nomisweb.co.uk/api/v01/help",
         "api_type": "FETCH",
-        "description_short": "STEM employee density",
-        "description": "Percentage of population employed in science, research, engineering and technology professional by NUTS 2 regions.",
+        "subtitle": "STEM employee density",
+        "title": "Percentage of population employed in science, research, engineering and technology professional by NUTS 2 regions.",
         "endpoint_url": {
           "2010": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1908408321...1908408356&date=latestMINUS27,latestMINUS23,latestMINUS19&variable=1543&measures=20599,21001,21002,21003,",
           "2013": "https://www.nomisweb.co.uk/api/v01/dataset/NM_17_5.jsonstat.json?geography=1887436801...1887436839&date=latestMINUS15,latestMINUS11,latestMINUS7&variable=1543&measures=20599,21001,21002,21003,",
@@ -1050,7 +1029,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Percentage of population employed in professional occupations.",
             "format": ".1f",
             "id": "aps_econ_active_stem_density_data",
             "label": "Percentage",
@@ -1074,9 +1052,9 @@
         "api_type": "MySQL",
         "auth_provider": "Nesta",
         "data_date": 20200922,
-        "description_long": "The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.",
-        "description_short": "Total tech companies founded",
-        "description": "The total numer of technology companies founded according to Crunchbase.",
+        "description": "The total number of technology companies founded according to Crunchbase. Technology companies were identified using their industry sector group labels provided by Crunchbase. In this case, the companies must belong to one of: Apps, Artificial Intelligence, Biotechnology, Consumer Electronics, Data and Analytics, Energy, Gaming, Hardware, Information Technology, Internet Services, Manufacturing, Mobile, Platforms, Science and Engineering or Software. These sectors represent groupings of the 700+ more granular sector labels that Crunchbase uses to categorise companies. The number of companies in this indicator is likely to be an underestimate due to the methods that Crunchbase uses to collect data (a mix of data sharing agreements with venture programmes, community crowdsourcing, machine learning and in-house data collection methods). In addition, some companies in Crunchbase are not associated with a location.",
+        "subtitle": "Total tech companies founded",
+        "title": "The total numer of technology companies founded according to Crunchbase.",
         "framework_group": "business_rnd_capacity",
         "is_experimental": true,
         "is_public": false,
@@ -1101,7 +1079,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total number of technology companies founded.",
             "id": "companies_founded",
             "label": "Number of companies founded"
           },
@@ -1124,8 +1101,8 @@
         "api_type": "FETCH",
         "auth_provider": "Nesta",
         "data_date": 20200218,
-        "description_short": "Venture capital investment",
-        "description": "Level of venture capital investment in ventures based on a region based on data from CrunchBase. A small number of deals have been converted to GBP at the date when they were announced.",
+        "subtitle": "Venture capital investment",
+        "title": "Level of venture capital investment in ventures based on a region based on data from CrunchBase. A small number of deals have been converted to GBP at the date when they were announced.",
         "endpoint_url": "https://crunchbase-export.s3.eu-west-2.amazonaws.com/organizations.csv",
         "framework_group": "business_rnd_capacity",
         "is_experimental": true,
@@ -1150,7 +1127,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total amount of venture capital invested in organisations in the location",
             "format": ",",
             "id": "gbp_venture_capital_received",
             "label": "Venture capital investment received",
@@ -1172,8 +1148,8 @@
       {
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm",
         "api_type": "FETCH",
-        "description_short": "Business enterprise R&D",
-        "description": "Business enterprise research & development (R&D) expenditure by NUTS 2 regions.",
+        "subtitle": "Business enterprise R&D",
+        "title": "Business enterprise research & development (R&D) expenditure by NUTS 2 regions.",
         "endpoint_url": "http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=6&sectperf=BES&unit=MIO_EUR",
         "framework_group": "business_rnd_capacity",
         "is_experimental": false,
@@ -1197,7 +1173,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "business enterprise R&D expenditure in euros (to the nearest 1000)",
             "format": ",",
             "id": "eurostat_berd_data",
             "label": "Expenditure (to nearest 1000)",
@@ -1219,8 +1194,8 @@
       {
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm",
         "api_type": "FETCH",
-        "description_short": "FTE of R&D workforce",
-        "description": "Full time equivalent (FTE) of private sector research & development (R&D) workforce-  by NUTS 2 regions.",
+        "subtitle": "FTE of R&D workforce",
+        "title": "Full time equivalent (FTE) of private sector research & development (R&D) workforce-  by NUTS 2 regions.",
         "endpoint_url": "http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_p_persreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=1&sex=T&sectperf=BES&prof_pos=TOTAL&unit=FTE",
         "framework_group": "business_rnd_capacity",
         "is_experimental": false,
@@ -1243,7 +1218,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Full time equivalent of workforce",
             "format": ".2f",
             "id": "eurostat_private_rd_fte_workforce_data",
             "label": "Full Time Equivalent",
@@ -1266,8 +1240,8 @@
       {
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm",
         "api_type": "FETCH",
-        "description_short": "HC of R&D workforce",
-        "description": "Head count (HC) OF private sector research & development (R&D) workforce by NUTS 2 regions.",
+        "subtitle": "HC of R&D workforce",
+        "title": "Head count (HC) OF private sector research & development (R&D) workforce by NUTS 2 regions.",
         "endpoint_url": "http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_p_persreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=1&sex=T&sectperf=BES&prof_pos=TOTAL&unit=HC",
         "framework_group": "business_rnd_capacity",
         "is_experimental": false,
@@ -1290,7 +1264,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Head count of workforce",
             "id": "eurostat_private_rd_headcount_workforce_data",
             "label": "Head count",
             "data_type": "int"
@@ -1312,8 +1285,8 @@
         "api_doc_url": "https://www.nomisweb.co.uk/api/v01/help",
         "api_type": "POST",
         "data_date": 20200218,
-        "description_short": "Economic Complexity Index",
-        "description": "This indicator measures the economic complexity of a location based on an analysis of its industrial composition ((based on Nesta sectoral definition, which clusters 4-digit SIC codes based on their similarity))",
+        "subtitle": "Economic Complexity Index",
+        "title": "This indicator measures the economic complexity of a location based on an analysis of its industrial composition ((based on Nesta sectoral definition, which clusters 4-digit SIC codes based on their similarity))",
         "endpoint_url": "http://www.nomisweb.co.uk/api/v01/dataset/",
         "framework_group": "business_rnd_capacity",
         "is_experimental": true,
@@ -1336,7 +1309,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Economic complexity Index",
             "format": ".4f",
             "id": "economic_complexity_index",
             "label": "Economic complexity Index",
@@ -1367,9 +1339,9 @@
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/pat_esms.htm",
         "api_type": "FETCH",
         "data_date": 20200818,
-        "description_long": "Patent applications are a proxy for inventions. We focus on applications to the European Patent Office (EPO). The year is the priority year for the patent i.e. the first year that the patent was filed with any patenting authority. There are significant lags between patent applications and publication, which explains the low timeliness of the data.",
-        "description_short": "Patent applications (EPO)",
-        "description": "Count of patent applications normalised by the number of applicants in a patent if there are more than one",
+        "description": "Patent applications are a proxy for inventions. We focus on applications to the European Patent Office (EPO). The year is the priority year for the patent i.e. the first year that the patent was filed with any patenting authority. There are significant lags between patent applications and publication, which explains the low timeliness of the data.",
+        "subtitle": "Patent applications (EPO)",
+        "title": "Count of patent applications normalised by the number of applicants in a patent if there are more than one",
         "endpoint_url": "https://appsso.eurostat.ec.europa.eu/nui/show.do?dataset=pat_ep_rtot&lang=en",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1393,7 +1365,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Count of patent applications",
             "id": "epo_patent_applications",
             "label": "Patent applications"
           },
@@ -1415,9 +1386,9 @@
         "api_doc_url": "https://ec.europa.eu/eurostat/cache/metadata/en/ipr_t_esms.htm",
         "api_type": "FETCH",
         "data_date": 20200818,
-        "description_long": "Trademark applications are a proxy for commercialisation. This indiator captures trademark registrations in the EU.",
-        "description_short": "Trademark",
-        "description": "Count of trademark applications",
+        "description": "Trademark applications are a proxy for commercialisation. This indiator captures trademark registrations in the EU.",
+        "subtitle": "Trademark",
+        "title": "Count of trademark applications",
         "endpoint_url": "https://appsso.eurostat.ec.europa.eu/nui/show.do?dataset=ipr_ta_reg&lang=en",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1441,7 +1412,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Count of trademark applications",
             "id": "eu_trademark_applications",
             "label": "Trademark applications"
           },
@@ -1463,9 +1433,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200928,
-        "description_long": "Income from continuing professional development and continuing education.",
-        "description_short": "Continuing professional development and education income",
         "description": "Income from continuing professional development and continuing education.",
+        "subtitle": "Continuing professional development and education income",
+        "title": "Income from continuing professional development and continuing education.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1491,7 +1461,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Continuing professional development and education income",
             "id": "ce_cpd_income",
             "label": "Income",
             "type": "GBP"
@@ -1513,9 +1482,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200928,
-        "description_long": "Number of continuing professional development and continuing education learner days",
-        "description_short": "Continuing professional development and education learner days",
         "description": "Number of continuing professional development and continuing education learner days",
+        "subtitle": "Continuing professional development and education learner days",
+        "title": "Number of continuing professional development and continuing education learner days",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2b.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1541,7 +1510,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Continuing professional development and education learner days",
             "id": "ce_cpd_learner_days",
             "label": "Days"
           },
@@ -1562,9 +1530,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.",
-        "description_short": "Collaborative research funding",
-        "description": "Cash value of collaborations with non-academic parterns.",
+        "description": "Value of collaborations with non-academic partners. This indicator only considers the value of collaborations in cash and excludes the value of in-kind collaboration.",
+        "subtitle": "Collaborative research funding",
+        "title": "Cash value of collaborations with non-academic parterns.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-1.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1590,7 +1558,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Collaborative research funding",
             "id": "collaborative_research_cash",
             "label": "Collaborative research income",
             "type": "GBP"
@@ -1612,9 +1579,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income for higher education institutions from providing consultancy and facilities services to non-SME companies.",
-        "description_short": "HE consultancy and facilities income from non-SME companies",
         "description": "Income for higher education institutions from providing consultancy and facilities services to non-SME companies.",
+        "subtitle": "HE consultancy and facilities income from non-SME companies",
+        "title": "Income for higher education institutions from providing consultancy and facilities services to non-SME companies.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1640,7 +1607,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Contract research income",
             "id": "consultancy_facilities_non_sme",
             "label": "Income from consultancy and facilities",
             "type": "GBP"
@@ -1662,9 +1628,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations.",
-        "description_short": "HE consultancy and facilities income from public and third sector organisations",
-        "description": "Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations",
+        "description": "Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations.",
+        "subtitle": "HE consultancy and facilities income from public and third sector organisations",
+        "title": "Income for higher education institutions from providing consultancy and facilities services to public and third sector organisations",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1690,7 +1656,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Contract research income",
             "id": "consultancy_facilities_public_third",
             "label": "Income from consultancy and facilities",
             "type": "GBP"
@@ -1712,9 +1677,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income for higher education institutions from providing consultancy and facilities services to SMEs",
-        "description_short": "HE consultancy and facilities income from SMEs",
         "description": "Income for higher education institutions from providing consultancy and facilities services to SMEs",
+        "subtitle": "HE consultancy and facilities income from SMEs",
+        "title": "Income for higher education institutions from providing consultancy and facilities services to SMEs",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1740,7 +1705,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Contract research income",
             "id": "consultancy_facilities_sme",
             "label": "Income from consultancy and facilities",
             "type": "GBP"
@@ -1762,9 +1726,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income for higher education institutions from providing contract research services to non-SME companies.",
-        "description_short": "HE contract research income from non-SME companies",
         "description": "Income for higher education institutions from providing contract research services to non-SME companies.",
+        "subtitle": "HE contract research income from non-SME companies",
+        "title": "Income for higher education institutions from providing contract research services to non-SME companies.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1790,7 +1754,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Contract research income",
             "id": "contract_research_non_sme",
             "label": "Income from contract research",
             "type": "GBP"
@@ -1812,9 +1775,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income for higher education institutions from providing contract research services to public and third sector organisations.",
-        "description_short": "HE contract research income from public and third sector organisations",
-        "description": "Income for higher education institutions from providing contract research services to public and third sector organisations",
+        "description": "Income for higher education institutions from providing contract research services to public and third sector organisations.",
+        "subtitle": "HE contract research income from public and third sector organisations",
+        "title": "Income for higher education institutions from providing contract research services to public and third sector organisations",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1840,7 +1803,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Contract research income",
             "id": "contract_research_public_third",
             "label": "Income from contract research",
             "type": "GBP"
@@ -1862,9 +1824,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income for higher education institutions from providing contract research services to SMEs.",
-        "description_short": "HE contract research income from SMEs",
         "description": "Income for higher education institutions from providing contract research services to SMEs.",
+        "subtitle": "HE contract research income from SMEs",
+        "title": "Income for higher education institutions from providing contract research services to SMEs.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-2a.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1890,7 +1852,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Contract research income",
             "id": "contract_research_sme",
             "label": "Income from contract research",
             "type": "GBP"
@@ -1912,8 +1873,8 @@
         "api_doc_url": "https://www.hesa.ac.uk/support/definitions/hebci",
         "api_type": "FETCH",
         "data_date": 20202002,
-        "description_short": "Current turnover of active university spinoffs",
-        "description": "Total current turnover of active spinoffs involving local universities in academic year starting in year",
+        "subtitle": "Current turnover of active university spinoffs",
+        "title": "Total current turnover of active spinoffs involving local universities in academic year starting in year",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1937,7 +1898,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total current turnover of active spinoffs involving local universities in academic year starting in year",
             "format": ",",
             "id": "gbp_turnover_per_active_spinoff",
             "label": "Current turnover of active university spinoffs",
@@ -1960,9 +1920,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200928,
-        "description_long": "Number of active startups founded by higher education graduates.",
-        "description_short": "Active graduate startups",
         "description": "Number of active startups founded by higher education graduates.",
+        "subtitle": "Active graduate startups",
+        "title": "Number of active startups founded by higher education graduates.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -1988,7 +1948,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Active graduate startups",
             "id": "graduate_startups",
             "label": "Startups"
           },
@@ -2009,9 +1968,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.",
-        "description_short": "HE intellectual property income",
-        "description": "Income from intellectual property by higher education providers.",
+        "description": "Income from intellectual property (including patents, copyright, design, registration and trade marks) by higher education providers.",
+        "subtitle": "HE intellectual property income",
+        "title": "Income from intellectual property by higher education providers.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4d.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -2037,7 +1996,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "HE intellectual property income",
             "id": "ip_revenue",
             "label": "Income",
             "type": "GBP"
@@ -2059,9 +2017,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/business-community/regeneration",
         "api_type": "FETCH",
         "data_date": 20200924,
-        "description_long": "Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \\\"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\\\" The indicator values represent the sum of income from all public bodies.",
-        "description_short": "HE regeneration and development income",
-        "description": "Income for higher education institutions from public regeneration and development programmes.",
+        "description": "Income for higher education institutions from public regeneration and development programmes. This funding is described by HESA as \\\"a way for HE providers to invest intellectual assets in economic, physical and socially beneficial projects.\\\" The indicator values represent the sum of income from all public bodies.",
+        "subtitle": "HE regeneration and development income",
+        "title": "Income for higher education institutions from public regeneration and development programmes.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-3.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -2087,7 +2045,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Regeneration and development income",
             "id": "regeneration_development",
             "label": "Income from regeneration and development",
             "type": "GBP"
@@ -2109,9 +2066,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200928,
-        "description_long": "Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).",
-        "description": "Total external investment in all spin-off activities associated with higher education institutions.",
-        "description_short": "Investment in higher education spin-offs",
+        "description": "Total external investment in all spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).",
+        "title": "Total external investment in all spin-off activities associated with higher education institutions.",
+        "subtitle": "Investment in higher education spin-offs",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -2137,7 +2094,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Investment in higher education spin-offs",
             "id": "spinoff_investment",
             "label": "Investment",
             "type": "GBP"
@@ -2159,9 +2115,9 @@
         "api_doc_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/",
         "api_type": "FETCH",
         "data_date": 20200928,
-        "description_long": "Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).",
-        "description_short": "Total turnover of higher education spin-offs",
-        "description": "Total turnover of all spin-off activities associated with higher education institutions.",
+        "description": "Total turnover of all active spin-off activities associated with higher education institutions (spin-offs with some HEP ownership, formal spin-offs not HEP owned, staff start-ups, graduate start-ups and social enterprises).",
+        "subtitle": "Total turnover of higher education spin-offs",
+        "title": "Total turnover of all spin-off activities associated with higher education institutions.",
         "endpoint_url": "https://www.hesa.ac.uk/data-and-analysis/providers/business-community/table-4e.csv",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -2187,7 +2143,6 @@
           },
           "value": {
             "data_type": "int",
-            "description": "Total turnover of higher education spin-offs",
             "id": "spinoff_revenue",
             "label": "Turnover",
             "type": "GBP"
@@ -2209,8 +2164,8 @@
         "api_doc_url": "https://github.com/nestauk/patent_analysis/raw/master/references/patstat_data_dict.pdf",
         "api_type": "MySQL",
         "data_date": 20202002,
-        "description_short": "Total unique inventions",
-        "description": "Total number of unique inventions involving organisations in the NUTS2 region in a year (we consider the earliest application year for all patents in the family)",
+        "subtitle": "Total unique inventions",
+        "title": "Total number of unique inventions involving organisations in the NUTS2 region in a year (we consider the earliest application year for all patents in the family)",
         "endpoint_url": "https://github.com/nestauk/imt_playbook/blob/dev/daps/sql.md",
         "framework_group": "knowledge_exchange",
         "is_experimental": true,
@@ -2233,7 +2188,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Total number of unique inventions involving organisations in the NUTS2 region in a year (we consider the earliest application year for all patents in the family)",
             "id": "total_inventions",
             "label": "Total unique inventions",
             "data_type": "int"
@@ -2255,8 +2209,8 @@
         "api_doc_url": "https://www.gov.uk/government/publications/ipo-trade-mark-data-release/ipo-data-explained-2016",
         "api_type": "FETCH",
         "data_date": 20200225,
-        "description_short": "Total number of trademarks",
-        "description": "Total number of trademarks published by organisations in the region based on the IPO open trademark dataset",
+        "subtitle": "Total number of trademarks",
+        "title": "Total number of trademarks published by organisations in the region based on the IPO open trademark dataset",
         "endpoint_url": "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/680986/opendatadomestic.zip",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -2279,7 +2233,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Total number of trademarks published by organisations in the region based on the IPO open trademark dataset",
             "id": "total_trademarks",
             "label": "Total trademarks",
             "data_type": "int"
@@ -2301,8 +2254,8 @@
         "api_doc_url": "https://www.gov.uk/government/publications/ipo-trade-mark-data-release/ipo-data-explained-2016",
         "api_type": "FETCH",
         "data_date": 20200225,
-        "description_short": "Total number of trademarks in science and technology fields",
-        "description": "Total number of trademarks in scientific and technological product fields published by organisations in the region based on the IPO open trademark dataset",
+        "subtitle": "Total number of trademarks in science and technology fields",
+        "title": "Total number of trademarks in scientific and technological product fields published by organisations in the region based on the IPO open trademark dataset",
         "endpoint_url": "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/680986/opendatadomestic.zip",
         "framework_group": "knowledge_exchange",
         "is_experimental": false,
@@ -2325,7 +2278,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Total number of trademarks in scientific and technological product fields published by organisations in the region based on the IPO open trademark dataset",
             "id": "total_trademarks_scientific",
             "label": "Total number of trademarks in science and technology fields",
             "data_type": "int"
@@ -2353,8 +2305,8 @@
     "indicators": [
       {
         "api_type": "FETCH",
-        "description_short": "Broadband speed",
-        "description": "Broadband download speed by NUTS 2 regions.",
+        "subtitle": "Broadband speed",
+        "title": "Broadband download speed by NUTS 2 regions.",
         "endpoint_url": {
           "2010": "https://webarchive.nationalarchives.gov.uk/20160703065525/http://www.ofcom.org.uk/static/research/ir/Fixed_postcode.zip",
           "2013": [
@@ -2388,7 +2340,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Broadband download speed.",
             "format": ".3f",
             "id": "broadband_download_speed_data",
             "label": "Download Speed",
@@ -2409,8 +2360,8 @@
       {
         "api_doc_url": "https://uk-air.defra.gov.uk/data/pcm-data",
         "api_type": "FETCH",
-        "description_short": "Mean PM10 particulate background pollution",
-        "description": "Mean PM10 particulate background pollution data at NUTS 2 regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.",
+        "subtitle": "Mean PM10 particulate background pollution",
+        "title": "Mean PM10 particulate background pollution data at NUTS 2 regions aggregated from 1km x 1km resolution UK data modelled by DEFRA.",
         "endpoint_url": {
           "2007": "https://uk-air.defra.gov.uk/datastore/pcm/mappm102007g.csv",
           "2008": "https://uk-air.defra.gov.uk/datastore/pcm/mappm102008g.csv",
@@ -2447,7 +2398,6 @@
             "type": "NutsRegion.year_spec"
           },
           "value": {
-            "description": "mean pm10 particulate pollution value",
             "format": ".2f",
             "id": "air_pollution_mean_pm10",
             "label": "Mean PM10 Pollution",
@@ -2478,9 +2428,9 @@
           "House price index (HPI)": "FETCH"
         },
         "data_date": 20201808,
-        "description_long": "This indicator captures housing costs in a location. It takes the mean price of a house in a location and normalises it by the mean salary of its residents. Higher values represent lower house affordability for residents",
-        "description_short": "Housing prices normalised by resident salaries",
-        "description": "Salary and Housing price data is available at the Local Authority District levels so we had to convert mean salaries (house prices) into volumes taking into account the number of people employed (transactions undertaken) in a location and aggregate at the NUTS level through a lookup table.",
+        "description": "This indicator captures housing costs in a location. It takes the mean price of a house in a location and normalises it by the mean salary of its residents. Higher values represent lower house affordability for residents",
+        "subtitle": "Housing prices normalised by resident salaries",
+        "title": "Salary and Housing price data is available at the Local Authority District levels so we had to convert mean salaries (house prices) into volumes taking into account the number of people employed (transactions undertaken) in a location and aggregate at the NUTS level through a lookup table.",
         "endpoint_url": {
           "Annual Survey of Hours and Earnings resident data (ASHE)": "https://www.nomisweb.co.uk/api/v01/dataset/NM_30_1.data.csv",
           "Business Register Employment Survey (BRES)": "https://www.nomisweb.co.uk/api/v01/dataset/NM_189_1.data.csv",
@@ -2509,7 +2459,6 @@
           },
           "value": {
             "data_type": "float",
-            "description": "Mean housing prices normalised by mean salaries of full time",
             "format": ".3f",
             "id": "house_price_normalised",
             "label": "Housing prices normalised by regional salaries"
@@ -2537,8 +2486,8 @@
         "api_doc_url": "https://www.nomisweb.co.uk/api/v01/help",
         "api_type": "POST",
         "data_date": 20200218,
-        "description_short": "Employment in cultural, entertainment and leisure industries",
-        "description": "This indicator measures level of employment in cultural, entertainment and leisure industries based on the Business Register Employment Survey. Those sectors are identified as clusters of SIC-4 (industry) codes",
+        "subtitle": "Employment in cultural, entertainment and leisure industries",
+        "title": "This indicator measures level of employment in cultural, entertainment and leisure industries based on the Business Register Employment Survey. Those sectors are identified as clusters of SIC-4 (industry) codes",
         "endpoint_url": "http://www.nomisweb.co.uk/api/v01/dataset/",
         "framework_group": "place_potential",
         "is_experimental": true,
@@ -2561,7 +2510,6 @@
             "type": "NutsRegion.nuts_year_spec"
           },
           "value": {
-            "description": "Total employment in cultural, entertainment and leisure industries",
             "id": "employment_culture_entertainment_recreation",
             "label": "Employment in cultural, entertainment and leisure industries",
             "data_type": "int"

--- a/ui/src/routes/indicators/[id]/[year].svelte
+++ b/ui/src/routes/indicators/[id]/[year].svelte
@@ -97,9 +97,8 @@
 		api_type,
 		auth_provider,
 		data_date,
-		description_long,
-		description_short,
 		description,
+		title,
 		endpoint_url,
 		is_public,
 		query,
@@ -107,6 +106,7 @@
 		schema,
 		source_name,
 		source_url,
+		subtitle,
 		url,
 		warning,
 		year_extent,
@@ -282,14 +282,14 @@
 </script>
 
 <svelte:head>
-	<title>BEIS indicators - {description_short} ({year})</title>
+	<title>BEIS indicators - {subtitle} ({year})</title>
 </svelte:head>
 
 <div class='container'>
 	<header>
 		<div>
-			<h1>{description_short} ({year})</h1>
-			<p>{description}</p>
+			<h1>{subtitle} ({year})</h1>
+			<p>{title}</p>
 		</div>
 		<div on:click={toggleInfoModal}>
 			<IconInfo
@@ -475,7 +475,7 @@
 			{api_type}
 			{auth_provider}
 			{data_date}
-			{description_long}
+			{description}
 			{endpoint_url}
 			{is_public}
 			{query}

--- a/ui/src/routes/indicators/[id]/index.svelte
+++ b/ui/src/routes/indicators/[id]/index.svelte
@@ -108,9 +108,8 @@
 		api_type,
 		auth_provider,
 		data_date,
-		description_short,
-		description_long,
 		description,
+		title,
 		endpoint_url,
 		is_public,
 		query,
@@ -118,6 +117,7 @@
 		schema,
 		source_name,
 		source_url,
+		subtitle,
 		url,
 		warning,
 		year_extent,
@@ -241,14 +241,14 @@
 </script>
 
 <svelte:head>
-	<title>BEIS indicators - {description_short}</title>
+	<title>BEIS indicators - {subtitle}</title>
 </svelte:head>
 
 <div class='container'>
 	<header>
 		<div>
-			<h1>{description_short}</h1>
-			<p>{description}</p>
+			<h1>{subtitle}</h1>
+			<p>{title}</p>
 		</div>
 		<div on:click={toggleInfoModal}>
 			<IconInfo
@@ -451,7 +451,7 @@
 			{api_type}
 			{auth_provider}
 			{data_date}
-			{description_long}
+			{description}
 			{endpoint_url}
 			{is_public}
 			{query}

--- a/ui/src/routes/indicators/_layout.svelte
+++ b/ui/src/routes/indicators/_layout.svelte
@@ -58,7 +58,7 @@
 		{#each groups as {label, indicators}}
 		<div class='group'>
 			<h2>{label}</h2>
-			{#each indicators as {description_short, schema}}
+			{#each indicators as {subtitle, schema}}
 			<a
 				rel='prefetch'
 				href='indicators/{schema.value.id}'
@@ -71,7 +71,7 @@
 						scrollableHeight
 					}}
 				>
-				{description_short}
+				{subtitle}
 				</p>
 			</a>
 			{/each}

--- a/ui/src/routes/indicators/index.svelte
+++ b/ui/src/routes/indicators/index.svelte
@@ -38,10 +38,10 @@
 		bind:clientWidth={width}
 	>
 		<ul>
-			{#each groups as {description, id, indicators, label}}
+			{#each groups as {title, id, indicators, label}}
 			<div class="group">
 				<h2>{label}</h2>
-				<p>{description}</p>
+				<p>{title}</p>
 
 				{#if width}
 				<svg
@@ -65,7 +65,7 @@
 					</g>
 					{/each}
 
-					{#each indicators as {description_short, schema, year_extent}, y}
+					{#each indicators as {subtitle, schema, year_extent}, y}
 					<g
 						class='indicatorsrange'
 						transform='translate(0,{vStep * (y + 1)})'
@@ -75,12 +75,12 @@
 							x='{(layout.scaleX(year_extent[0]) + layout.scaleX(year_extent[1])) / 2}'
 							dy='{-(layout.fontSize + gap)}'
 							font-size={layout.fontSize}
-						>{description_short}</text>
+						>{subtitle}</text>
 						<text
 							x='{(layout.scaleX(year_extent[0]) + layout.scaleX(year_extent[1])) / 2}'
 							dy='{-(layout.fontSize + gap)}'
 							font-size={layout.fontSize}
-						>{description_short}</text>
+						>{subtitle}</text>
 						<line
 							x1='{layout.scaleX(year_extent[0]) + layout.radius}'
 							x2='{layout.scaleX(year_extent[1]) - layout.radius}'


### PR DESCRIPTION
- `description_long` -> `description`
- `description_short` -> `subtitle`
- `description` -> `title`

Closes #361

Also:
- deleted `schema.value.description`
- clarified how to use `data_type` with currencies