### PR TITLE
541 eurostat link update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ## Tool
 
 - Add Open Graph meta tags, rollup adjustments (#523)
-ß
+
 # 0.1.2
 
 ## Tool

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 - Fix the downloadable zip file not containing all of the expected files (#530)
 - Deployment scripts log and error out when some schemas are malformed (#531)
+- Change of eurostat links, from API to website (#541)
 
 # 0.1.3
 
 ## Tool
 
 - Add Open Graph meta tags, rollup adjustments (#523)
-
+ß
 # 0.1.2
 
 ## Tool

--- a/ds/data/processed/eurostat/eurostat_berd_data.nuts2.yaml
+++ b/ds/data/processed/eurostat/eurostat_berd_data.nuts2.yaml
@@ -2,7 +2,7 @@ api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
 title: Business enterprise R&D
 subtitle: Business enterprise research & development (R&D) expenditure by NUTS 2 regions.
-endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2012&geoLevel=nuts2&precision=6&sectperf=BES&unit=MIO_EUR
+endpoint_url: https://ec.europa.eu/eurostat/databrowser/bookmark/6091cb33-9192-43eb-a534-6a5e22be3cd6?lang=en
 framework_group: private_rnd
 is_experimental: False
 order: [year, nuts_id, nuts_year_spec, value.id] # do not change; specifies the order of the exported indicator fields

--- a/ds/data/processed/eurostat/eurostat_gov_rd_workforce_data.nuts2.yaml
+++ b/ds/data/processed/eurostat/eurostat_gov_rd_workforce_data.nuts2.yaml
@@ -2,7 +2,7 @@ api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
 title: Government R&D
 subtitle: Government performed research & development (R&D) expenditure by NUTS 2 regions.
-endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2007&geoLevel=nuts2&precision=2&sectperf=GOV&unit=MIO_EUR
+endpoint_url: https://ec.europa.eu/eurostat/databrowser/bookmark/7cb28f37-d3c1-408a-aef4-615e8dbbf950?lang=en
 framework_group: public_rnd
 is_experimental: False
 order: [year, nuts_id, nuts_year_spec, value.id] # do not change; specifies the order of the exported indicator fields

--- a/ds/data/processed/eurostat/eurostat_higher_ed_rd_workforce_data.nuts2.yaml
+++ b/ds/data/processed/eurostat/eurostat_higher_ed_rd_workforce_data.nuts2.yaml
@@ -2,7 +2,7 @@ api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
 title: Higher Edu R&D
 subtitle: Higher education sector enterprise research & development (R&D) expenditure by NUTS 2 regions.
-endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2007&geoLevel=nuts2&precision=6&sectperf=HES&unit=MIO_EUR'
+endpoint_url: https://ec.europa.eu/eurostat/databrowser/bookmark/9edc14ee-3e3e-44e4-98c9-32e358e28abf?lang=en
 framework_group: public_rnd
 is_experimental: False
 order: [year, nuts_id, nuts_year_spec, value.id] # do not change; specifies the order of the exported indicator fields

--- a/ds/data/processed/eurostat/eurostat_private_non_profit_rd_workforce_data.nuts2.yaml
+++ b/ds/data/processed/eurostat/eurostat_private_non_profit_rd_workforce_data.nuts2.yaml
@@ -2,7 +2,7 @@ api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
 title: Private non-profit R&D
 subtitle: Private non-profit sector enterprise research & development (R&D) expenditure by NUTS 2 regions.
-endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_e_gerdreg?sinceTimePeriod=2007&geoLevel=nuts2&precision=6&sectperf=PNP&unit=MIO_EUR'
+endpoint_url: https://ec.europa.eu/eurostat/databrowser/bookmark/872cd1a9-32b8-474b-a1d2-d6ad2ccc3e1e?lang=en
 framework_group: private_rnd
 is_experimental: False
 order: [year, nuts_id, nuts_year_spec, value.id] # do not change; specifies the order of the exported indicator fields

--- a/ds/data/processed/eurostat/eurostat_private_rd_fte_workforce_data.nuts2.yaml
+++ b/ds/data/processed/eurostat/eurostat_private_rd_fte_workforce_data.nuts2.yaml
@@ -2,7 +2,7 @@ api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
 title: FTE of R&D workforce
 subtitle: Full time equivalent (FTE) of private sector research & development (R&D) workforce by NUTS 2 regions.
-endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_p_persreg?sinceTimePeriod=2007&geoLevel=nuts2&precision=1&sex=T&sectperf=BES&prof_pos=TOTAL&unit=FTE
+endpoint_url: https://ec.europa.eu/eurostat/databrowser/bookmark/48101866-78ab-466e-b312-b6f49441a45c?lang=en
 framework_group: private_rnd
 is_experimental: False
 order: [year, nuts_id, nuts_year_spec, value.id] # do not change; specifies the order of the exported indicator fields

--- a/ds/data/processed/eurostat/eurostat_private_rd_headcount_workforce_data.nuts2.yaml
+++ b/ds/data/processed/eurostat/eurostat_private_rd_headcount_workforce_data.nuts2.yaml
@@ -2,7 +2,7 @@ api_doc_url: https://ec.europa.eu/eurostat/cache/metadata/en/rd_esms.htm
 api_type: FETCH
 title: HC of R&D workforce
 subtitle: Head count (HC) OF private sector research & development (R&D) workforce by NUTS 2 regions.
-endpoint_url: http://ec.europa.eu/eurostat/wdds/rest/data/v2.1/json/en/rd_p_persreg?sinceTimePeriod=2007&geoLevel=nuts2&precision=1&sex=T&sectperf=BES&prof_pos=TOTAL&unit=HC
+endpoint_url: https://ec.europa.eu/eurostat/databrowser/bookmark/b19c38ea-b194-4e87-85ff-eaf8d95de0e3?lang=en
 framework_group: private_rnd
 is_experimental: False
 order: [year, nuts_id, nuts_year_spec, value.id] # do not change; specifies the order of the exported indicator fields


### PR DESCRIPTION
Replaced API endpoint links (raw data JSONs) to the Eurostar data explorer version for the following Eurostat indicators:

- `eurostat_berd_data`
- `eurostat_gov_rd_workforce_data`
- `eurostat_higher_ed_rd_workforce_data`
- `eurostat_private_rd_fte_workforce_data`
- `eurostat_private_rd_headcount_workforce_data`